### PR TITLE
chore(desktop): update Tauri to 2.9.5

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4060,9 +4060,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -9,14 +9,14 @@ edition = "2021"
 rust-version = "1.70"
 
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "2.1", features = [] }
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri = { version = "2", features = [] }
-tauri-plugin-dialog = "2"
-tauri-plugin-shell = "2"
+tauri = { version = "2.5", features = [] }
+tauri-plugin-dialog = "2.2"
+tauri-plugin-shell = "2.2"
 tauri-plugin-pty = "0.2"
 
 [profile.release]


### PR DESCRIPTION
## Summary
- Pin minimum Tauri versions to ensure latest security fixes
- Updates tauri to 2.5+, tauri-build to 2.1+, and plugins to 2.2+
- Resolves to Tauri 2.9.5 (current latest)

## Note on glib vulnerability
The glib 0.18.5 vulnerability (RUSTSEC-2024-0429) cannot be fixed via cargo update. It requires wry to upgrade to gtk4-rs, which is tracked in [tauri-apps/wry#1474](https://github.com/tauri-apps/wry/issues/1474).

The Dependabot alert has been dismissed with this explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)