### PR TITLE
fix: deploy docs to /docs/ path

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -34,11 +34,29 @@ jobs:
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - run: touch src/rustfava/static/app.js
       - run: just docs
+      - name: Restructure for /docs path
+        run: |
+          mkdir -p build/site/docs
+          mv build/docs/* build/site/docs/
+          cat > build/site/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta charset="utf-8">
+            <meta http-equiv="refresh" content="0; url=docs/">
+            <link rel="canonical" href="docs/">
+            <title>Redirecting to rustfava docs</title>
+          </head>
+          <body>
+            <p>Redirecting to <a href="docs/">documentation</a>...</p>
+          </body>
+          </html>
+          EOF
       - if: github.repository == 'rustledger/rustfava'
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          path: "build/docs"
+          path: "build/site"
           retention-days: 1
   deploy:
     if: github.repository == 'rustledger/rustfava' && github.event_name == 'push'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Rustfava
 site_description: Web interface for rustledger, a Rust-based Beancount parser
-site_url: https://rustledger.github.io/rustfava/
+site_url: https://rustledger.github.io/rustfava/docs/
 repo_url: https://github.com/rustledger/rustfava
 repo_name: rustledger/rustfava
 


### PR DESCRIPTION
## Summary
- Move mkdocs documentation from root to `/docs/` subdirectory
- Root path now redirects to `/docs/`

## Changes
- `mkdocs.yml`: Update `site_url` to `https://rustledger.github.io/rustfava/docs/`
- `docs-pages.yml`: Restructure build output, add redirect index.html

## Result
- `rustledger.github.io/rustfava/` → redirects to `/docs/`
- `rustledger.github.io/rustfava/docs/` → mkdocs documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)