### PR TITLE
chore: remove root redirect for docs

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -38,20 +38,6 @@ jobs:
         run: |
           mkdir -p build/site/docs
           mv build/docs/* build/site/docs/
-          cat > build/site/index.html << 'EOF'
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <meta charset="utf-8">
-            <meta http-equiv="refresh" content="0; url=docs/">
-            <link rel="canonical" href="docs/">
-            <title>Redirecting to rustfava docs</title>
-          </head>
-          <body>
-            <p>Redirecting to <a href="docs/">documentation</a>...</p>
-          </body>
-          </html>
-          EOF
       - if: github.repository == 'rustledger/rustfava'
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0


### PR DESCRIPTION
Remove the index.html redirect at root, only deploy docs to /docs/ path.