### PR TITLE
fix: use Python 3.13 in desktop workflows

### DIFF
--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
## Summary
- Updates desktop-release.yml and desktop-nightly.yml to use Python 3.13 instead of 3.12
- rustfava requires Python >= 3.13, causing sidecar builds to fail

## Test plan
- [ ] Verify desktop release workflow succeeds after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)