### PR TITLE
fix: add bun and bash shell for sidecar builds

### DIFF
--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -81,6 +81,9 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Get latest rustledger tag
         id: rustledger-tag
+        shell: bash
         run: |
           TAG=$(git ls-remote --tags --sort=-v:refname https://github.com/${{ env.RUSTLEDGER_REPO }}.git "v*" | head -1 | sed 's/.*refs\/tags\///' | sed 's/\^{}//')
           echo "tag=$TAG" >> $GITHUB_OUTPUT
@@ -73,6 +74,9 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.13'
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
## Summary
- Adds `shell: bash` to the "Get latest rustledger tag" step in desktop-release.yml
  - Windows defaults to PowerShell which doesn't understand bash syntax like `TAG=$(...)`
- Adds bun installation step before Python dependencies in both desktop workflows
  - `pip install -e .` triggers the build backend which requires bun for frontend compilation

## Test plan
- [ ] Verify all sidecar builds succeed after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)