### PR TITLE
fix: use classic linker on macOS to avoid Xcode 15 crashes

### DIFF
--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -144,7 +144,13 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build rustledger CLI binaries
-        run: cargo build --release --target ${{ matrix.target }}
+        shell: bash
+        run: |
+          # macOS: Use classic linker to avoid Xcode 15 crashes on long symbol names
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            export RUSTFLAGS="-C link-arg=-Wl,-ld_classic"
+          fi
+          cargo build --release --target ${{ matrix.target }}
 
       - name: Prepare binaries (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -144,7 +144,13 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build rustledger CLI binaries
-        run: cargo build --release --target ${{ matrix.target }}
+        shell: bash
+        run: |
+          # macOS: Use classic linker to avoid Xcode 15 crashes on long symbol names
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            export RUSTFLAGS="-C link-arg=-Wl,-ld_classic"
+          fi
+          cargo build --release --target ${{ matrix.target }}
 
       - name: Prepare binaries (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- Adds `RUSTFLAGS="-C link-arg=-Wl,-ld_classic"` for macOS builds
- Xcode 15 crashes on long symbol names with the new linker
- This matches the fix used in rustledger/rustledger release workflow

## Test plan
- [ ] Verify macOS ARM64 rustledger build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)