### PR TITLE
fix: use macos-latest for x86_64-apple-darwin builds

### DIFF
--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -41,7 +41,7 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             sidecar_name: rustfava-server-x86_64-unknown-linux-gnu
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             sidecar_name: rustfava-server-x86_64-apple-darwin
           - os: macos-14
@@ -120,7 +120,7 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             ext: ''
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             ext: ''
           - os: macos-14
@@ -192,7 +192,7 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             sidecar_name: rustfava-server-x86_64-unknown-linux-gnu
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             sidecar_name: rustfava-server-x86_64-apple-darwin
           - os: macos-14

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -27,7 +27,7 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             sidecar_name: rustfava-server-x86_64-unknown-linux-gnu
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             sidecar_name: rustfava-server-x86_64-apple-darwin
           - os: macos-14
@@ -112,7 +112,7 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             ext: ''
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             ext: ''
           - os: macos-14
@@ -192,7 +192,7 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             sidecar_name: rustfava-server-x86_64-unknown-linux-gnu
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             sidecar_name: rustfava-server-x86_64-apple-darwin
           - os: macos-14


### PR DESCRIPTION
## Summary
- Replace macos-13 with macos-latest for Intel Mac builds
- Cross-compiles on ARM runners (Intel runners deprecated)
- Matches rustledger's approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)