### PR TITLE
fix: remove conflicting libappindicator3-dev package

### DIFF
--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -228,7 +228,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
             librsvg2-dev \
             patchelf \
             libssl-dev \

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -228,7 +228,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
             librsvg2-dev \
             patchelf \
             libssl-dev \


### PR DESCRIPTION
## Summary
- Remove `libappindicator3-dev` which conflicts with `libayatana-appindicator3-dev`
- Keep only `libayatana-appindicator3-dev` (modern replacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)