### PR TITLE
fix: pass target to Tauri build for cross-compilation

### DIFF
--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -256,19 +256,20 @@ jobs:
         with:
           projectPath: desktop
           tauriScript: bun tauri
+          args: --target ${{ matrix.target }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:
           name: rustfava-${{ matrix.target }}
           path: |
-            desktop/src-tauri/target/release/bundle/deb/*.deb
-            desktop/src-tauri/target/release/bundle/rpm/*.rpm
-            desktop/src-tauri/target/release/bundle/appimage/*.AppImage
-            desktop/src-tauri/target/release/bundle/dmg/*.dmg
-            desktop/src-tauri/target/release/bundle/macos/*.app
-            desktop/src-tauri/target/release/bundle/msi/*.msi
-            desktop/src-tauri/target/release/bundle/nsis/*.exe
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
 
   release:
     needs: build-tauri

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -256,19 +256,20 @@ jobs:
         with:
           projectPath: desktop
           tauriScript: bun tauri
+          args: --target ${{ matrix.target }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:
           name: rustfava-${{ matrix.target }}
           path: |
-            desktop/src-tauri/target/release/bundle/deb/*.deb
-            desktop/src-tauri/target/release/bundle/rpm/*.rpm
-            desktop/src-tauri/target/release/bundle/appimage/*.AppImage
-            desktop/src-tauri/target/release/bundle/dmg/*.dmg
-            desktop/src-tauri/target/release/bundle/macos/*.app
-            desktop/src-tauri/target/release/bundle/msi/*.msi
-            desktop/src-tauri/target/release/bundle/nsis/*.exe
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
 
   release:
     needs: build-tauri


### PR DESCRIPTION
## Summary
- Add `args: --target ${{ matrix.target }}` to tauri-action
- Update artifact paths to `target/${{ matrix.target }}/release/bundle/`
- Fixes cross-compilation on macos-latest (ARM) for Intel builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)