### PR TITLE
docs: restyle README to match rustledger format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,72 @@
-# Rustfava
+<div align="center">
 
-Rustfava is a web interface for the double-entry bookkeeping software
-[rustledger](https://github.com/rustledger/rustledger), a Rust-based
-implementation of the Beancount format.
+# rustfava
 
-This is a fork of [Fava](https://github.com/beancount/fava) that replaces the
-Python beancount parser with rustledger, compiled to WebAssembly for faster
-parsing and processing.
+**A beautiful desktop app for [rustledger](https://github.com/rustledger/rustledger)**
+
+Manage your finances with plain text accounting.
+
+[![CI](https://github.com/rustledger/rustfava/actions/workflows/ci.yml/badge.svg)](https://github.com/rustledger/rustfava/actions/workflows/ci.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/rustledger/rustfava)](https://github.com/rustledger/rustfava/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![PyPI](https://img.shields.io/pypi/v/rustfava)](https://pypi.org/project/rustfava/)
 
 ![rustfava dashboard](docs/screenshot.png)
 
-## Getting Started
+</div>
 
-### Option 1: Desktop App (Recommended)
+---
 
-Download the desktop app from [GitHub Releases](https://github.com/rustledger/rustfava/releases):
+## Why rustfava?
 
-- **macOS**: `rustfava_x.x.x_universal.dmg`
-- **Windows**: `rustfava_x.x.x_x64-setup.exe`
-- **Linux**: `rustfava_x.x.x_amd64.AppImage`
+| | |
+|---|---|
+| **Native app** | Double-click to launch, no terminal required |
+| **Fava interface** | The familiar Fava web UI you know and love |
+| **rustledger backend** | Blazing fast parsing via WebAssembly |
+| **Cross-platform** | Linux, macOS (Intel & Apple Silicon), Windows |
+| **Offline first** | Your financial data stays on your machine |
+| **Multiple files** | Open multiple ledgers in tabs |
 
-Double-click to launch, then open your `.beancount` file.
+## Install
 
-### Option 2: Docker
+| Platform | Download |
+|----------|----------|
+| **macOS** | [`rustfava_0.1.0_aarch64.dmg`](https://github.com/rustledger/rustfava/releases/download/v0.1.0/rustfava_0.1.0_aarch64.dmg) |
+| **Windows** | [`rustfava_0.1.0_x64-setup.exe`](https://github.com/rustledger/rustfava/releases/download/v0.1.0/rustfava_0.1.0_x64-setup.exe) |
+| **Linux** | [`rustfava_0.1.0_amd64.AppImage`](https://github.com/rustledger/rustfava/releases/download/v0.1.0/rustfava_0.1.0_amd64.AppImage) |
+| **Docker** | `docker run -p 5000:5000 -v /path/to/ledger:/data ghcr.io/rustledger/rustfava /data/main.beancount` |
+| **PyPI** | `uv tool install rustfava` (requires Python 3.13+ and [wasmtime](https://wasmtime.dev/)) |
 
-Run the server in a container:
+<sub>Missing your platform? [Open an issue](https://github.com/rustledger/rustfava/issues/new) to request it.</sub>
+
+## Quick Start
+
+### Desktop App
+
+1. Download the app for your platform
+2. Double-click to launch
+3. Open your `.beancount` file
+
+### Command Line
 
 ```bash
-docker run -p 5000:5000 -v /path/to/ledger:/data ghcr.io/rustledger/rustfava /data/main.beancount
-```
-
-Then visit [http://localhost:5000](http://localhost:5000).
-
-### Option 3: uv install
-
-For developers or advanced users. Requires Python 3.13+ and [wasmtime](https://wasmtime.dev/):
-
-```bash
-uv tool install rustfava
 rustfava ledger.beancount
+# Then visit http://localhost:5000
 ```
 
-Then visit [http://localhost:5000](http://localhost:5000).
+## What is this?
 
-## Development
+rustfava is a fork of [Fava](https://github.com/beancount/fava) that replaces the Python beancount parser with [rustledger](https://github.com/rustledger/rustledger), compiled to WebAssembly for faster parsing and processing.
 
-See the repository for development instructions. Contributions are welcome!
+The desktop app bundles everything into a native application using [Tauri](https://tauri.app/), so you get a fast, lightweight app with no dependencies.
 
 ## Links
 
-- Source: https://github.com/rustledger/rustfava
-- Documentation: https://rustledger.github.io/rustfava/
+- **Website**: https://rustledger.github.io/rustfava/
+- **Documentation**: https://rustledger.github.io/rustfava/docs/
+- **rustledger**: https://github.com/rustledger/rustledger
+
+## License
+
+MIT License - see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- Restyle README to match the rustledger repo format
- Add centered header with title, tagline, and badges
- Add "Why rustfava?" feature table
- Add Install table with platform-specific download links
- Add Quick Start guide for desktop and CLI usage
- Keep the screenshot and relevant content

🤖 Generated with [Claude Code](https://claude.com/claude-code)