### PR TITLE
fix: bundle example beancount file in desktop app

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -29,6 +29,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": {
+      "../../contrib/examples/example.beancount": "examples/"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Problem
Clicking "Open Example Beancount File" in the desktop app shows "Example file not found" error.

## Cause
The example file at `contrib/examples/example.beancount` was not configured to be bundled in the Tauri app resources.

## Fix
Added `resources` configuration to `tauri.conf.json` to include the example file in the bundle at `examples/example.beancount`.

## Test plan
- [ ] Build AppImage and verify example file loads
- [ ] Build DMG and verify example file loads
- [ ] Build Windows installer and verify example file loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)