### PR TITLE
fix: correct resources path for example file bundling

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -39,8 +39,8 @@ fn get_example_file_path(app: AppHandle) -> Result<String, String> {
     let resource_dir = app.path().resource_dir()
         .map_err(|e| format!("Failed to get resource dir: {}", e))?;
 
-    // Try bundled resource first
-    let bundled_path = resource_dir.join("examples").join("example.beancount");
+    // Try bundled resource first (copied to resources root by Tauri)
+    let bundled_path = resource_dir.join("example.beancount");
     if bundled_path.exists() {
         return Ok(bundled_path.to_string_lossy().to_string());
     }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -29,9 +29,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "resources": {
-      "../../contrib/examples/example.beancount": "examples/"
-    },
+    "resources": [
+      "../../contrib/examples/example.beancount"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Fixes 'Is a directory (os error 21)' build failure by using array syntax for resources.