### PR TITLE
feat: add COPR support for Fedora/RHEL packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,20 @@
-name: Build and publish (PyPI + Docker on tags)
+# Build and Publish Workflow
+# =========================
+# Triggered on tags to publish to multiple distribution channels:
+#
+# | Channel | Registry/URL                           |
+# |---------|----------------------------------------|
+# | PyPI    | pypi.org/project/rustfava             |
+# | Docker  | ghcr.io/rustledger/rustfava           |
+# | COPR    | copr.fedorainfracloud.org/robcohen    |
+#
+# SECRETS REQUIRED
+# ----------------
+# - COPR_LOGIN / COPR_TOKEN: COPR build trigger
+# - (PyPI uses OIDC trusted publishing, no token needed)
+# - (Docker uses GITHUB_TOKEN)
+#
+name: Build and publish (PyPI + Docker + COPR on tags)
 
 on:
   workflow_dispatch:
@@ -104,3 +120,32 @@ jobs:
             ghcr.io/${{ github.repository }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Trigger COPR build for Fedora/RHEL
+  copr:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: publish  # Wait for PyPI publish so source is available
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Install copr-cli
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
+          pip3 install copr-cli
+      - name: Configure COPR
+        run: |
+          mkdir -p ~/.config
+          cat > ~/.config/copr << EOF
+          [copr-cli]
+          login = ${{ secrets.COPR_LOGIN }}
+          username = robcohen
+          token = ${{ secrets.COPR_TOKEN }}
+          copr_url = https://copr.fedorainfracloud.org
+          EOF
+      - name: Trigger SCM build
+        run: |
+          # Trigger a build using COPR's PyPI integration
+          copr-cli build-package robcohen/rustfava \
+            --name rustfava \
+            --nowait || true

--- a/packaging/rpm/rustfava.spec
+++ b/packaging/rpm/rustfava.spec
@@ -1,0 +1,62 @@
+%global debug_package %{nil}
+
+Name:           rustfava
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        Web interface for rustledger double-entry accounting
+
+License:        MIT
+URL:            https://github.com/rustledger/rustfava
+Source0:        %{pypi_source rustfava}
+
+BuildArch:      noarch
+BuildRequires:  python3-devel >= 3.13
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools >= 80
+BuildRequires:  python3-setuptools_scm >= 8
+BuildRequires:  python3-babel >= 2.7
+BuildRequires:  python3-wheel
+
+Requires:       python3 >= 3.13
+Requires:       python3-flask >= 2.2
+Requires:       python3-flask-babel >= 3
+Requires:       python3-jinja2 >= 3
+Requires:       python3-werkzeug >= 2.2
+Requires:       python3-click >= 7
+Requires:       python3-markdown2 >= 2.3
+Requires:       python3-ply >= 3.11
+Requires:       python3-pydantic >= 2.0
+Requires:       python3-cheroot >= 8
+Requires:       python3-watchfiles >= 0.20
+Requires:       wasmtime
+
+%description
+rustfava is a web interface for viewing and exploring rustledger/beancount
+accounting files. It provides reports, charts, and an interactive query
+interface for double-entry bookkeeping.
+
+Features:
+- Income statement, balance sheet, and other standard reports
+- Interactive charts and graphs
+- BQL query interface
+- Editor with syntax highlighting
+- Multi-file ledger support
+
+%prep
+%autosetup -n rustfava-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files rustfava
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.md
+%{_bindir}/rustfava
+
+%changelog
+* Sat Jan 25 2026 rustfava <rustfava@users.noreply.github.com> - 0.1.0-1
+- Initial package


### PR DESCRIPTION
## Summary
- Adds RPM spec file at `packaging/rpm/rustfava.spec`
- Adds COPR trigger job to publish workflow
- Builds are triggered automatically when a new release is published to PyPI

## Setup Required
Before this works, you need to:
1. Create a COPR project at https://copr.fedorainfracloud.org
2. Configure it to build from PyPI source
3. Add `COPR_LOGIN` and `COPR_TOKEN` secrets to the repo

## Usage (after setup)
```bash
sudo dnf copr enable robcohen/rustfava
sudo dnf install rustfava
```

## Note
The spec file requires:
- Fedora 41+ (Python 3.13)
- `wasmtime` package (may need to be added to COPR build deps or installed separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)