### PR TITLE
fix: add bun to nightly package for frontend compilation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,9 +69,10 @@
         };
 
         # Nightly runner - installs from git main branch
+        # Requires bun for frontend compilation when building from source
         rustfava-nightly = pkgs.writeShellApplication {
           name = "rustfava";
-          runtimeInputs = [ pkgs.python313 pkgs.uv pkgs.wasmtime pkgs.git ];
+          runtimeInputs = [ pkgs.python313 pkgs.uv pkgs.wasmtime pkgs.git pkgs.bun ];
           text = ''
             RUSTFAVA_HOME="''${XDG_DATA_HOME:-$HOME/.local/share}/rustfava-nightly"
             VENV="$RUSTFAVA_HOME/venv"


### PR DESCRIPTION
## Summary
Building from git source requires `bun` to compile the frontend. The stable PyPI package has pre-built assets, but nightly builds from source.

Fixes `RuntimeError: bun is missing` when running `nix run github:rustledger/rustfava#nightly`

🤖 Generated with [Claude Code](https://claude.com/claude-code)