### PR TITLE
fix: use --no-build-isolation for nightly to access bun

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,10 @@
               echo "Installing rustfava (nightly from main branch)..."
               mkdir -p "$RUSTFAVA_HOME"
               uv venv "$VENV" --python ${pkgs.python313}/bin/python
-              uv pip install --python "$VENV/bin/python" "git+https://github.com/rustledger/rustfava.git"
+              # Install build dependencies first (needed for --no-build-isolation)
+              uv pip install --python "$VENV/bin/python" setuptools setuptools_scm Babel wheel
+              # --no-build-isolation ensures bun is available during frontend compilation
+              uv pip install --python "$VENV/bin/python" --no-build-isolation "git+https://github.com/rustledger/rustfava.git"
             fi
 
             exec "$VENV/bin/rustfava" "$@"


### PR DESCRIPTION
## Summary
uv's build isolation creates a separate environment that doesn't have access to the nix-provided `bun`. This fix:

1. Pre-installs build dependencies (setuptools, setuptools_scm, Babel, wheel)
2. Uses `--no-build-isolation` so bun is accessible during frontend compilation

Tested locally - `nix run .#nightly -- --version` now works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)