### PR TITLE
fix(nix): disable WebKitGTK compositing for EGL compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,6 +119,9 @@
               chmod +x "$APPIMAGE"
             fi
 
+            # Disable WebKitGTK compositing to avoid EGL issues on NixOS
+            export WEBKIT_DISABLE_COMPOSITING_MODE=1
+
             # Run the AppImage with rustfava in PATH (for PATH fallback feature)
             exec appimage-run "$APPIMAGE" "$@"
           '';


### PR DESCRIPTION
## Summary
Sets `WEBKIT_DISABLE_COMPOSITING_MODE=1` to avoid EGL display errors when running the AppImage on NixOS.

Fixes:
```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)