### PR TITLE
fix(desktop): allow rustfava command in shell capabilities

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -13,6 +13,11 @@
           "name": "binaries/rustfava-server",
           "sidecar": true,
           "args": true
+        },
+        {
+          "name": "rustfava",
+          "cmd": "rustfava",
+          "args": true
         }
       ]
     },


### PR DESCRIPTION
Allow rustfava from PATH in Tauri shell capabilities for NixOS native builds.