### PR TITLE
feat: add tarball release for NixOS and simplify flake

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -275,11 +275,25 @@ jobs:
           tauriScript: bun tauri
           args: --target ${{ matrix.target }}
 
+      - name: Create tarball (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          mkdir -p tarball-staging/bin tarball-staging/lib/rustfava/resources
+          # Copy main binary
+          cp desktop/src-tauri/target/${{ matrix.target }}/release/rustfava-desktop tarball-staging/bin/
+          # Copy sidecars (server + rustledger CLI tools)
+          cp desktop/src-tauri/binaries/* tarball-staging/bin/
+          # Copy resources
+          cp contrib/examples/example.beancount tarball-staging/lib/rustfava/resources/
+          # Create tarball
+          tar -czvf rustfava-desktop-${{ matrix.target }}.tar.gz -C tarball-staging .
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: rustfava-${{ matrix.target }}
           path: |
+            rustfava-desktop-${{ matrix.target }}.tar.gz
             desktop/src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
             desktop/src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
             desktop/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
@@ -308,6 +322,7 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           files: |
+            artifacts/**/*.tar.gz
             artifacts/**/*.deb
             artifacts/**/*.rpm
             artifacts/**/*.AppImage

--- a/flake.lock
+++ b/flake.lock
@@ -37,28 +37,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769222645,
-        "narHash": "sha256-gu6oZ86zLudBZMq8LL1qdtYt/S69GV5keQVXdvBrVSU=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "22da29e7f3d8cff75009cbbcf992c7cb66920cfd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,138 +4,114 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    rust-overlay.url = "github:oxalica/rust-overlay";
-    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+  outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ rust-overlay.overlays.default ];
+        pkgs = import nixpkgs { inherit system; };
+
+        # Version to download from releases
+        version = "0.1.0";
+
+        # Target triple for the current platform
+        targetTriple =
+          if pkgs.stdenv.isLinux then
+            if pkgs.stdenv.hostPlatform.isx86_64 then "x86_64-unknown-linux-gnu"
+            else if pkgs.stdenv.hostPlatform.isAarch64 then "aarch64-unknown-linux-gnu"
+            else throw "Unsupported Linux architecture"
+          else if pkgs.stdenv.isDarwin then
+            if pkgs.stdenv.hostPlatform.isAarch64 then "aarch64-apple-darwin"
+            else "x86_64-apple-darwin"
+          else throw "Unsupported platform";
+
+        # Download desktop tarball from GitHub releases
+        desktopTarball = pkgs.fetchurl {
+          url = "https://github.com/rustledger/rustfava/releases/download/v${version}/rustfava-desktop-${targetTriple}.tar.gz";
+          # TODO: Update hash after first release with tarball
+          hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
         };
 
-        # Rust toolchain with WASM target
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-          targets = [ "wasm32-wasip1" ];
+        # Desktop app from release tarball
+        rustfava-desktop = pkgs.stdenv.mkDerivation {
+          pname = "rustfava-desktop";
+          inherit version;
+
+          src = desktopTarball;
+          sourceRoot = ".";
+
+          nativeBuildInputs = with pkgs; [
+            autoPatchelfHook
+            makeWrapper
+          ];
+
+          buildInputs = with pkgs; [
+            stdenv.cc.cc.lib
+            openssl
+          ] ++ lib.optionals stdenv.isLinux [
+            webkitgtk_4_1
+            libsoup_3
+            glib-networking
+            gtk3
+            glib
+            cairo
+            pango
+            gdk-pixbuf
+            librsvg
+          ];
+
+          installPhase = ''
+            mkdir -p $out
+            cp -r bin lib $out/
+
+            # Wrap all binaries with wasmtime in PATH and GTK settings
+            for bin in $out/bin/*; do
+              if [ -f "$bin" ] && [ -x "$bin" ]; then
+                wrapProgram "$bin" \
+                  --prefix PATH : "${pkgs.wasmtime}/bin" \
+                  --set GIO_MODULE_DIR "${pkgs.glib-networking}/lib/gio/modules" \
+                  --prefix XDG_DATA_DIRS : "${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}"
+              fi
+            done
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Desktop app for rustfava - double-entry bookkeeping";
+            homepage = "https://github.com/rustledger/rustfava";
+            license = licenses.mit;
+            platforms = platforms.linux;
+            mainProgram = "rustfava-desktop";
+          };
         };
 
-        # Python with Rustfava dependencies
+        # Python with Rustfava dependencies for dev shell
         pythonEnv = pkgs.python313.withPackages (ps: with ps; [
-          # Rustfava core dependencies
-          flask
-          flask-babel
-          jinja2
-          markdown2
-          ply  # Used for filter syntax parsing
-          watchfiles
-          werkzeug
-          click
-          markupsafe
-          cheroot  # WSGI server for rustfava CLI
-
-          # Beancount (optional - for legacy plugin support)
-          beancount
-          beangulp
-
-          # Dev/test dependencies
-          pytest
-          pytest-cov
-
-          # Build dependencies
-          setuptools
-          wheel
-          build
+          flask flask-babel jinja2 markdown2 ply watchfiles werkzeug
+          click markupsafe cheroot beancount beangulp
+          pytest pytest-cov setuptools wheel build
         ]);
 
-        # Rustfava runner script - installs via uv on first run (stable from PyPI)
+        # Rustfava CLI - installs via uv on first run from PyPI
         rustfava = pkgs.writeShellApplication {
           name = "rustfava";
           runtimeInputs = [ pkgs.python313 pkgs.uv pkgs.wasmtime ];
           text = ''
             RUSTFAVA_HOME="''${XDG_DATA_HOME:-$HOME/.local/share}/rustfava"
             VENV="$RUSTFAVA_HOME/venv"
-
             if [ ! -f "$VENV/bin/rustfava" ]; then
-              echo "Installing rustfava..."
+              echo "Installing rustfava from PyPI..."
               mkdir -p "$RUSTFAVA_HOME"
               uv venv "$VENV" --python ${pkgs.python313}/bin/python
               uv pip install --python "$VENV/bin/python" rustfava
             fi
-
             exec "$VENV/bin/rustfava" "$@"
           '';
         };
-
-        # Nightly runner - installs from git main branch
-        # Requires bun for frontend compilation when building from source
-        rustfava-nightly = pkgs.writeShellApplication {
-          name = "rustfava";
-          runtimeInputs = [ pkgs.python313 pkgs.uv pkgs.wasmtime pkgs.git pkgs.bun ];
-          text = ''
-            RUSTFAVA_HOME="''${XDG_DATA_HOME:-$HOME/.local/share}/rustfava-nightly"
-            VENV="$RUSTFAVA_HOME/venv"
-
-            if [ ! -f "$VENV/bin/rustfava" ]; then
-              echo "Installing rustfava (nightly from main branch)..."
-              mkdir -p "$RUSTFAVA_HOME"
-              uv venv "$VENV" --python ${pkgs.python313}/bin/python
-              # Install build dependencies first (needed for --no-build-isolation)
-              uv pip install --python "$VENV/bin/python" setuptools setuptools_scm Babel wheel
-              # --no-build-isolation ensures bun is available during frontend compilation
-              uv pip install --python "$VENV/bin/python" --no-build-isolation "git+https://github.com/rustledger/rustfava.git"
-            fi
-
-            exec "$VENV/bin/rustfava" "$@"
-          '';
-        };
-
-        # Desktop app runner for NixOS
-        # Downloads AppImage from releases and wraps with rustfava in PATH
-        mkDesktopApp = { name, rustfavaPkg }: pkgs.writeShellApplication {
-          inherit name;
-          runtimeInputs = [ rustfavaPkg pkgs.appimage-run pkgs.curl pkgs.jq ];
-          text = ''
-            RUSTFAVA_HOME="''${XDG_DATA_HOME:-$HOME/.local/share}/rustfava"
-            APPIMAGE="$RUSTFAVA_HOME/rustfava-desktop.AppImage"
-
-            # Check for updates and download AppImage if needed
-            if [ ! -f "$APPIMAGE" ]; then
-              echo "Downloading rustfava desktop app..."
-              mkdir -p "$RUSTFAVA_HOME"
-
-              # Get latest release AppImage URL
-              RELEASE_URL=$(curl -s https://api.github.com/repos/rustledger/rustfava/releases/latest \
-                | jq -r '.assets[] | select(.name | endswith(".AppImage")) | .browser_download_url')
-
-              if [ -z "$RELEASE_URL" ] || [ "$RELEASE_URL" = "null" ]; then
-                echo "Error: No AppImage found in latest release."
-                echo "The desktop app may not be released yet. Try running 'nix run .#default' for the CLI."
-                exit 1
-              fi
-
-              curl -L -o "$APPIMAGE" "$RELEASE_URL"
-              chmod +x "$APPIMAGE"
-            fi
-
-            # Disable WebKitGTK compositing to avoid EGL issues on NixOS
-            export WEBKIT_DISABLE_COMPOSITING_MODE=1
-
-            # Run the AppImage with rustfava in PATH (for PATH fallback feature)
-            exec appimage-run "$APPIMAGE" "$@"
-          '';
-        };
-
-        rustfava-desktop = mkDesktopApp { name = "rustfava-desktop"; rustfavaPkg = rustfava; };
-        rustfava-desktop-nightly = mkDesktopApp { name = "rustfava-desktop"; rustfavaPkg = rustfava-nightly; };
 
       in {
         packages = {
           default = rustfava;
-          nightly = rustfava-nightly;
           desktop = rustfava-desktop;
-          desktop-nightly = rustfava-desktop-nightly;
         };
 
         apps = {
@@ -143,96 +119,54 @@
             type = "app";
             program = "${rustfava}/bin/rustfava";
           };
-          nightly = {
-            type = "app";
-            program = "${rustfava-nightly}/bin/rustfava";
-          };
           desktop = {
             type = "app";
             program = "${rustfava-desktop}/bin/rustfava-desktop";
           };
-          desktop-nightly = {
-            type = "app";
-            program = "${rustfava-desktop-nightly}/bin/rustfava-desktop";
-          };
         };
 
+        # Dev shell for development
         devShells.default = pkgs.mkShell {
           packages = [
             pythonEnv
-
-            # WASM runtime for rustledger
             pkgs.wasmtime
+            pkgs.just pkgs.jq pkgs.fd pkgs.ripgrep pkgs.uv
+            pkgs.bun pkgs.nodejs_latest
 
-            # Dev tools
-            pkgs.just
-            pkgs.jq
-            pkgs.fd
-            pkgs.ripgrep
-            pkgs.uv  # Fast Python package manager
-
-            # Bun for frontend build
-            pkgs.bun
-
-            # Node.js 23+ for frontend tests (required for registerHooks API)
-            pkgs.nodejs_latest
-
-            # Rust toolchain with WASM target for Tauri desktop app
-            rustToolchain
-
-            # Tauri system dependencies
+            # Tauri/desktop development deps
+            pkgs.cargo-tauri
+            pkgs.rustc pkgs.cargo
             pkgs.pkg-config
             pkgs.openssl
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
             pkgs.webkitgtk_4_1
             pkgs.libsoup_3
             pkgs.glib-networking
+            pkgs.gtk3
             pkgs.librsvg
             pkgs.gsettings-desktop-schemas
-            pkgs.gtk3
-
           ];
 
           shellHook = ''
-            echo "🦀 Rustfava development environment"
-            echo ""
-            echo "Python: $(python --version)"
-            echo "Bun: $(bun --version)"
-            echo "wasmtime: $(wasmtime --version)"
-            echo ""
-            echo "WASM file: src/rustfava/rustledger/rustledger-wasi.wasm"
-            echo ""
+            echo "Rustfava development environment"
 
-            # GTK/GSettings environment for Tauri
+            # GTK environment for Tauri
             export XDG_DATA_DIRS="${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:$XDG_DATA_DIRS"
             export GIO_MODULE_DIR="${pkgs.glib-networking}/lib/gio/modules"
 
-            # Create/activate venv for additional packages not in nixpkgs
             if [ ! -d ".venv" ]; then
-              echo "Creating virtual environment..."
               uv venv .venv --system-site-packages
             fi
             source .venv/bin/activate
-
-            # Install additional Python packages not in nixpkgs via uv
             if [ ! -f ".venv/.uv-installed" ]; then
-              echo "Installing additional Python packages via uv..."
               uv pip install pyexcel pyexcel-ods3 pyexcel-xlsx
-              # Install rustfava in editable mode for package metadata (version, etc.)
               uv pip install -e . --no-deps
               touch .venv/.uv-installed
             fi
-
-            # Add src to PYTHONPATH for development
             export PYTHONPATH="$PWD/src:$PYTHONPATH"
 
-            # Create a wrapper script for the rustfava CLI so tests can find it
-            mkdir -p "$PWD/.dev-bin"
-            cat > "$PWD/.dev-bin/rustfava" << 'WRAPPER'
-#!/usr/bin/env bash
-exec python -m rustfava.cli "$@"
-WRAPPER
-            chmod +x "$PWD/.dev-bin/rustfava"
-            export PATH="$PWD/.dev-bin:$PATH"
+            echo ""
+            echo "For desktop development: cd desktop && bun install && bun run tauri:dev"
           '';
         };
       }


### PR DESCRIPTION
## Summary
- Add tarball creation step to desktop-release workflow for Linux
- Tarball includes desktop binary, sidecars (rustfava-server, rustledger CLI tools), and resources
- Simplify flake to download from GitHub releases instead of building from source
- CLI installs from PyPI via uv, desktop downloads release tarball
- Wrap binaries with wasmtime and GTK dependencies for NixOS compatibility

## Why
AppImage doesn't work well on NixOS due to EGL/graphics driver issues. A tarball allows nix to properly wrap the binaries with the necessary runtime dependencies.

## Test plan
- [ ] Merge and create v0.1.0 release
- [ ] Wait for workflow to produce tarball
- [ ] Update flake.nix hash with actual tarball hash
- [ ] Test `nix run .#desktop` on NixOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)