### PR TITLE
fix: install build dependencies before pip install -e .

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -92,7 +92,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pyinstaller
-          pip install -e .
+          # Install build dependencies first (custom build backend requires these)
+          pip install "setuptools>=80" "setuptools_scm>=8" "Babel>=2.7,<3" wheel
+          pip install --no-build-isolation -e .
 
       - name: Build sidecar with PyInstaller
         run: |


### PR DESCRIPTION
## Summary
Fix desktop release workflow failing with `Cannot import '_build_backend'` error.

The custom build backend requires setuptools, setuptools_scm, Babel, and wheel to be installed before pip can process the editable install. Added `--no-build-isolation` flag to use the installed deps.

## Test plan
- [ ] Merge and re-trigger v0.1.1 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)