### PR TITLE
feat: auto-update flake sources on release

### DIFF
--- a/.github/workflows/update-flake-sources.yml
+++ b/.github/workflows/update-flake-sources.yml
@@ -1,0 +1,103 @@
+name: Update Flake Sources
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g., v0.1.2)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-sources:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2571846004f8e5e32bc66d5e # v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Get version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
+          echo "tag=$VERSION" >> $GITHUB_OUTPUT
+          echo "Using version: $VERSION"
+
+      - name: Update desktop-sources.json
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+
+          # Define platforms and their target triples
+          declare -A PLATFORMS=(
+            ["x86_64-linux"]="x86_64-unknown-linux-gnu"
+          )
+
+          # Start building JSON
+          echo "{" > desktop-sources.json.new
+          echo "  \"version\": \"$VERSION\"," >> desktop-sources.json.new
+
+          FIRST=true
+          for PLATFORM in "${!PLATFORMS[@]}"; do
+            TARGET="${PLATFORMS[$PLATFORM]}"
+            URL="https://github.com/rustledger/rustfava/releases/download/$TAG/rustfava-desktop-$TARGET.tar.gz"
+
+            echo "Fetching hash for $PLATFORM ($TARGET)..."
+
+            # Check if the file exists
+            if curl --head --silent --fail "$URL" > /dev/null 2>&1; then
+              HASH=$(nix-prefetch-url --type sha256 "$URL" 2>/dev/null)
+              SRI_HASH=$(nix hash to-sri --type sha256 "$HASH")
+
+              if [ "$FIRST" = true ]; then
+                FIRST=false
+              else
+                echo "," >> desktop-sources.json.new
+              fi
+
+              echo "  \"$PLATFORM\": {" >> desktop-sources.json.new
+              echo "    \"url\": \"$URL\"," >> desktop-sources.json.new
+              echo "    \"hash\": \"$SRI_HASH\"" >> desktop-sources.json.new
+              echo -n "  }" >> desktop-sources.json.new
+
+              echo "  $PLATFORM: $SRI_HASH"
+            else
+              echo "  $PLATFORM: tarball not found, skipping"
+            fi
+          done
+
+          echo "" >> desktop-sources.json.new
+          echo "}" >> desktop-sources.json.new
+
+          # Pretty print with jq
+          jq '.' desktop-sources.json.new > desktop-sources.json
+          rm desktop-sources.json.new
+
+          echo "Updated desktop-sources.json:"
+          cat desktop-sources.json
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        with:
+          commit-message: "chore: update desktop sources for ${{ steps.version.outputs.tag }}"
+          title: "chore: update desktop sources for ${{ steps.version.outputs.tag }}"
+          body: |
+            Automated update of `desktop-sources.json` for release ${{ steps.version.outputs.tag }}.
+
+            This updates the Nix flake to use the new desktop release binaries.
+          branch: update-desktop-sources-${{ steps.version.outputs.version }}
+          delete-branch: true

--- a/desktop-sources.json
+++ b/desktop-sources.json
@@ -1,0 +1,7 @@
+{
+  "version": "0.1.2",
+  "x86_64-linux": {
+    "url": "https://github.com/rustledger/rustfava/releases/download/v0.1.2/rustfava-desktop-x86_64-unknown-linux-gnu.tar.gz",
+    "hash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  }
+}


### PR DESCRIPTION
## Summary
- Add `desktop-sources.json` to store version and hashes for each platform
- Update `flake.nix` to read sources from JSON file instead of hardcoded values
- Add `update-flake-sources` workflow that triggers on release publish

## How it works
1. When a release is published, the workflow runs
2. It downloads the tarball and computes the SRI hash using `nix-prefetch-url`
3. Updates `desktop-sources.json` with the new version and hash
4. Creates a PR with the changes

## Test plan
- [x] `nix flake check` passes
- [ ] Manual trigger of workflow after v0.1.2 release completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)