### PR TITLE
fix: add symlinks for sidecar binaries in Nix flake

### DIFF
--- a/contrib/pyinstaller_spec.spec
+++ b/contrib/pyinstaller_spec.spec
@@ -31,7 +31,7 @@ if static_dir.exists():
     for f in static_dir.rglob("*"):
         if f.is_file():
             rel_path = f.relative_to(rustfava_dir)
-            datas.append((str(f), str(rel_path.parent)))
+            datas.append((str(f), f"rustfava/{rel_path.parent}"))
 
 # Templates
 templates_dir = rustfava_dir / "templates"
@@ -39,14 +39,14 @@ if templates_dir.exists():
     for f in templates_dir.rglob("*"):
         if f.is_file():
             rel_path = f.relative_to(rustfava_dir)
-            datas.append((str(f), str(rel_path.parent)))
+            datas.append((str(f), f"rustfava/{rel_path.parent}"))
 
 # Translations (.mo files)
 translations_dir = rustfava_dir / "translations"
 if translations_dir.exists():
     for f in translations_dir.rglob("*.mo"):
         rel_path = f.relative_to(rustfava_dir)
-        datas.append((str(f), str(rel_path.parent)))
+        datas.append((str(f), f"rustfava/{rel_path.parent}"))
 
 # WASM file for rustledger
 wasm_file = rustfava_dir / "rustledger" / "rustledger-wasi.wasm"
@@ -59,7 +59,7 @@ if help_dir.exists():
     for f in help_dir.rglob("*"):
         if f.is_file():
             rel_path = f.relative_to(rustfava_dir)
-            datas.append((str(f), str(rel_path.parent)))
+            datas.append((str(f), f"rustfava/{rel_path.parent}"))
 
 # Hidden imports
 hiddenimports = [

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -148,16 +148,16 @@ fn spawn_rustfava_server(app: &AppHandle, path: &str, port: u16) -> Result<Comma
         }
     }
 
-    // Fall back to rustfava from PATH (for NixOS/system installs)
-    // This allows the desktop app to work when rustfava CLI is installed separately
+    // Fall back to rustfava-server from PATH (for NixOS flake installs)
+    // The flake creates symlinks without the target triple suffix
     let command = app
         .shell()
-        .command("rustfava")
+        .command("rustfava-server")
         .args([path, "-p", &port.to_string()]);
 
     let (_, child) = command
         .spawn()
-        .map_err(|e| format!("Failed to spawn rustfava: {}. Make sure rustfava is installed and in PATH.", e))?;
+        .map_err(|e| format!("Failed to spawn rustfava-server: {}. Make sure the desktop app is properly installed.", e))?;
 
     Ok(child)
 }

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,19 @@
             mkdir -p $out
             cp -r bin lib $out/
 
+            # Create symlinks without target triple suffix for PATH lookup
+            # The desktop app falls back to these when sidecar lookup fails
+            for bin in $out/bin/*-${targetTriple}*; do
+              if [ -f "$bin" ]; then
+                base=$(basename "$bin" | sed "s/-${targetTriple}//")
+                ln -sf "$(basename "$bin")" "$out/bin/$base"
+              fi
+            done
+
+            # Create rustfava -> rustfava-server symlink for backwards compatibility
+            # Old releases look for 'rustfava' in PATH as fallback
+            ln -sf "rustfava-server-${targetTriple}" "$out/bin/rustfava"
+
             # Wrap all binaries with wasmtime in PATH and GTK settings
             for bin in $out/bin/*; do
               if [ -f "$bin" ] && [ -x "$bin" ]; then


### PR DESCRIPTION
## Summary
- Add symlinks without target triple suffix for PATH lookup
- Add `rustfava` -> `rustfava-server` symlink for backwards compatibility with v0.1.2
- Update main.rs fallback to use `rustfava-server` directly (for future releases)

## Problem
`nix run github:rustledger/rustfava#desktop` failed because:
1. Tauri sidecar lookup fails outside bundle structure
2. Fallback looked for `rustfava` which didn't exist

## Test
```bash
nix run .#desktop
```
Now launches the app (though there's a separate internal server error to investigate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)