### PR TITLE
fix: add base branch to flake sources workflow

### DIFF
--- a/.github/workflows/update-flake-sources.yml
+++ b/.github/workflows/update-flake-sources.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
+          base: main
           commit-message: "chore: update desktop sources for ${{ steps.version.outputs.tag }}"
           title: "chore: update desktop sources for ${{ steps.version.outputs.tag }}"
           body: |


### PR DESCRIPTION
The create-pull-request action needs `base: main` when triggered by release events (which check out a tag, not a branch).