### PR TITLE
fix: enable include-package-data for wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,9 @@ backend-path = ["."]
 [tool.uv]
 python-preference = "system"
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.packages.find]
 where = ["src"]
 


### PR DESCRIPTION
## Summary

MANIFEST.in only affects **source distributions** (sdist). For **wheel builds**, setuptools needs `include-package-data = true` to include non-Python files like templates and static assets.

## Problem

Even after #61 added templates to MANIFEST.in, the Docker image still didn't have templates because:
1. Docker builds from source using `pip install .`
2. This creates a wheel, which doesn't use MANIFEST.in
3. Without `include-package-data = true`, setuptools doesn't include templates in the wheel

## Fix

Add `[tool.setuptools]` section with `include-package-data = true` to pyproject.toml.

## Testing

Verified templates are now included when building without `.git` (simulating Docker build):
```
=== Checking installed templates ===
-rw-r--r--  _layout.html
-rw-r--r--  _journal_table.html
-rw-r--r--  _query_table.html
...
```

Fixes rustledger/rustledger#300

🤖 Generated with [Claude Code](https://claude.com/claude-code)