### PR TITLE
fix: copy MANIFEST.in in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ WORKDIR /app
 
 # Copy source and frontend (needed for build backend)
 COPY pyproject.toml .
+COPY MANIFEST.in .
 COPY _build_backend.py .
 COPY src/ src/
 COPY frontend/ frontend/


### PR DESCRIPTION
## Problem

Even after PRs #61 and #63, templates were still missing in Docker builds because the Dockerfile didn't copy `MANIFEST.in`.

Without `MANIFEST.in`, `include-package-data = true` has no file list to work with.

## Fix

Add `COPY MANIFEST.in .` to Dockerfile.

## Root Cause Chain

1. **#61**: Added templates to MANIFEST.in (for sdist)
2. **#63**: Added `include-package-data = true` (to use MANIFEST.in for wheels)
3. **This PR**: Copy MANIFEST.in into Docker build context

Fixes rustledger/rustledger#300

🤖 Generated with [Claude Code](https://claude.com/claude-code)