### PR TITLE
chore: bump version to 0.1.10

### DIFF
--- a/src/rustfava/cli.py
+++ b/src/rustfava/cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import click
 
 # Version for PyInstaller builds where importlib.metadata is unavailable
-__version__ = "0.1.8"
+__version__ = "0.1.10"
 
 try:
     from importlib.metadata import version as get_version


### PR DESCRIPTION
## Summary

- Bump PyInstaller fallback version to 0.1.10

Preparing for v0.1.10 release to test FlakeHub workflow (#74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)