### PR TITLE
fix(ci): use correct SHAs for DeterminateSystems actions

### DIFF
--- a/.github/workflows/flakehub-publish-tagged.yml
+++ b/.github/workflows/flakehub-publish-tagged.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           persist-credentials: false
           ref: "${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}"
-      - uses: DeterminateSystems/determinate-nix-action@e2534ae04b9dc72e8d57d4cf0a87571b500e9533 # v3.2.0
-      - uses: DeterminateSystems/flakehub-push@5f4064d2f8bbc84c3f51f4e5d12d91e15f8a33f4 # v5
+      - uses: DeterminateSystems/determinate-nix-action@89ab342bd48ff7318caf8d39d6a330c7b1df8f2f # v3.15.2
+      - uses: DeterminateSystems/flakehub-push@8da9e38b7e77f2b0a8aa08a22e57cc5c6316ea72 # v5
         with:
           visibility: "public"
           name: "rustledger/rustfava"


### PR DESCRIPTION
## Summary

- Fix invalid commit SHAs for DeterminateSystems actions in FlakeHub workflow
- `determinate-nix-action@89ab342bd48ff7318caf8d39d6a330c7b1df8f2f` (v3.15.2)
- `flakehub-push@8da9e38b7e77f2b0a8aa08a22e57cc5c6316ea72` (v5)

The previous SHAs were invalid, causing the workflow to fail with:
> An action could not be found at the URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)