### PR TITLE
chore: bump version to 0.1.11

### DIFF
--- a/src/rustfava/cli.py
+++ b/src/rustfava/cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import click
 
 # Version for PyInstaller builds where importlib.metadata is unavailable
-__version__ = "0.1.10"
+__version__ = "0.1.11"
 
 try:
     from importlib.metadata import version as get_version


### PR DESCRIPTION
## Summary

- Bump PyInstaller fallback version to 0.1.11

Preparing for v0.1.11 release to test FlakeHub workflow with corrected action SHAs (#76).

🤖 Generated with [Claude Code](https://claude.com/claude-code)