### PR TITLE
fix: remove bean-* binaries no longer shipped by default

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -180,7 +180,7 @@ jobs:
           mkdir -p binaries
           tar -xzf rustledger.${{ matrix.archive }}
           # Rename binaries to include target triple (Tauri sidecar convention)
-          for bin in bean-check bean-doctor bean-extract bean-format bean-price bean-query bean-report rledger; do
+          for bin in rledger; do
             if [ -f "$bin" ]; then
               mv "$bin" "binaries/${bin}-${{ matrix.target }}"
             fi
@@ -192,7 +192,7 @@ jobs:
           mkdir -p binaries
           unzip rustledger.${{ matrix.archive }}
           # Rename binaries to include target triple (Tauri sidecar convention)
-          for bin in bean-check bean-doctor bean-extract bean-format bean-price bean-query bean-report rledger; do
+          for bin in rledger; do
             if [ -f "${bin}.exe" ]; then
               mv "${bin}.exe" "binaries/${bin}-${{ matrix.target }}.exe"
             fi

--- a/desktop/scripts/ensure-rustledger.ts
+++ b/desktop/scripts/ensure-rustledger.ts
@@ -20,8 +20,6 @@ const RUSTLEDGER_REPO = "https://github.com/rustledger/rustledger.git";
 
 // CLI binaries to build
 const CLI_BINARIES = [
-  "bean-check", "bean-doctor", "bean-extract", "bean-format",
-  "bean-price", "bean-query", "bean-report",
   "rledger"
 ];
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -41,13 +41,6 @@
     ],
     "externalBin": [
       "binaries/rustfava-server",
-      "binaries/bean-check",
-      "binaries/bean-doctor",
-      "binaries/bean-extract",
-      "binaries/bean-format",
-      "binaries/bean-price",
-      "binaries/bean-query",
-      "binaries/bean-report",
       "binaries/rledger"
     ],
     "linux": {

--- a/justfile
+++ b/justfile
@@ -301,5 +301,4 @@ clean-all: clean
     rm -rf .cache
     rm -f src/rustfava/rustledger/.wasm-version
     rm -f desktop/src-tauri/binaries/.cli-version-*
-    rm -f desktop/src-tauri/binaries/bean-*
     rm -f desktop/src-tauri/binaries/rledger-*


### PR DESCRIPTION
## Summary

- Remove all `bean-*` binary references from the desktop app build pipeline
- `rustledger/rustledger#872` made `bean-compat` opt-in, so `bean-check`, `bean-doctor`, `bean-extract`, `bean-format`, `bean-price`, `bean-query`, and `bean-report` are no longer included in release tarballs
- The desktop app should use `rledger` subcommands (e.g., `rledger check`, `rledger query`) directly instead

### Changes

- **`desktop/src-tauri/tauri.conf.json`** — Removed 7 bean-* entries from `externalBin`, keeping only `rustfava-server` and `rledger`
- **`desktop/scripts/ensure-rustledger.ts`** — Removed bean-* from `CLI_BINARIES` array, keeping only `rledger`
- **`.github/workflows/desktop-release.yml`** — Removed bean-* from the binary download/copy loops (tar.gz and zip extraction)
- **`justfile`** — Removed `bean-*` cleanup line from `clean-all` recipe (no longer needed)

## Test plan

- [ ] Verify `desktop-release.yml` workflow passes CI (only downloads `rledger` from release tarball)
- [ ] Verify desktop app builds and launches with only `rledger` sidecar
- [ ] Verify `just clean-all` still cleans up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)