### PR TITLE
fix(deps): update pytest and rand to resolve security advisories

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2240,7 +2240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2250,7 +2250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2512,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ docs = [
 # Type-checking with mypy.
 types = [
     "mypy>=1.14",
-    "pytest>=8",
+    "pytest>=8.4",
     "typeguard>=4",
     "types-requests>=2.32.0.20250515",
     "types-setuptools>=67",
@@ -95,7 +95,7 @@ test = [
     "rustfava[beancount-compat]",
     "pytest-cov>=6",
     "pytest-xdist>=3",
-    "pytest>=8",
+    "pytest>=8.4",
     "setuptools>=67",
     "typeguard>=4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1094,9 +1094,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1424,7 +1424,7 @@ provides-extras = ["excel", "beancount-compat"]
 dev = [
     { name = "mypy", specifier = ">=1.14" },
     { name = "pre-commit", specifier = ">=4" },
-    { name = "pytest", specifier = ">=8" },
+    { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-cov", specifier = ">=6" },
     { name = "pytest-xdist", specifier = ">=3" },
     { name = "ruff", specifier = ">=0.11" },
@@ -1446,7 +1446,7 @@ scripts = [
     { name = "requests", specifier = ">=2" },
 ]
 test = [
-    { name = "pytest", specifier = ">=8" },
+    { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-cov", specifier = ">=6" },
     { name = "pytest-xdist", specifier = ">=3" },
     { name = "rustfava", extras = ["beancount-compat"] },
@@ -1456,7 +1456,7 @@ test = [
 ]
 types = [
     { name = "mypy", specifier = ">=1.14" },
-    { name = "pytest", specifier = ">=8" },
+    { name = "pytest", specifier = ">=8.4" },
     { name = "typeguard", specifier = ">=4" },
     { name = "types-requests", specifier = ">=2.32.0.20250515" },
     { name = "types-setuptools", specifier = ">=67" },


### PR DESCRIPTION
## Summary

- **pytest** (pip, medium severity): Bump minimum version constraint from `>=8` to `>=8.4` to exclude versions vulnerable to CVE-2025-2804 (insecure tmpdir handling). Lock file updated from 9.0.2 to 9.0.3.
- **rand** (cargo, low severity): Update `rand` 0.8.5 -> 0.8.6 in `desktop/src-tauri/Cargo.lock` to address RUSTSEC-2024-0034 (unsoundness with custom logger using `rand::rng()`). This is a transitive dependency from tauri via phf_generator.

## Files changed

- `pyproject.toml` — pytest lower bound raised to 8.4
- `uv.lock` — regenerated with latest pytest
- `desktop/src-tauri/Cargo.lock` — rand updated to 0.8.6

## Test plan

- [ ] CI passes (no functional changes, only dependency version bumps)
- [ ] Dependabot security alerts are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)