### PR TITLE
test: accept rustledger v0.14 query error categorization

### DIFF
--- a/tests/test_core_query_shell.py
+++ b/tests/test_core_query_shell.py
@@ -89,7 +89,9 @@ def test_query_errors(run_query: Callable[[str], QueryResult]) -> None:
         run_query(".run custom_query other")
     with pytest.raises(QueryNotFoundError):
         run_query(".run unknown")
-    with pytest.raises(QueryParseError):
+    # Bare-word "asdf" was a parse error in rustledger ≤0.13; v0.14 routes
+    # the same input through the compilation path. Accept either.
+    with pytest.raises((QueryParseError, QueryCompilationError)):
         run_query("asdf")
     with pytest.raises(QueryCompilationError):
         run_query("select asdf")
@@ -115,7 +117,7 @@ def test_query_to_file(
         query_shell.query_to_file(entries, "run custom_query other", "csv")
     with pytest.raises(QueryNotFoundError):
         query_shell.query_to_file(entries, "run testsetest", "csv")
-    with pytest.raises(QueryParseError):
+    with pytest.raises((QueryParseError, QueryCompilationError)):
         query_shell.query_to_file(entries, "asdf", "csv")
     with pytest.raises(QueryCompilationError):
         query_shell.query_to_file(entries, "select asdf", "csv")

--- a/tests/test_json_api.py
+++ b/tests/test_json_api.py
@@ -808,7 +808,8 @@ def test_api_query_result_error(test_client: FlaskClient) -> None:
         query_string={"query_string": "nononono"},
     )
     msg = assert_api_error(response)
-    assert "Query parse error" in msg
+    # rustledger ≤0.13 → "Query parse error"; v0.14 → "Query compilation error".
+    assert "Query parse error" in msg or "Query compilation error" in msg
 
 
 def test_api_commodities_empty(


### PR DESCRIPTION
## Summary

- Broaden `test_query_errors` and `test_query_to_file` to accept either `QueryParseError` or `QueryCompilationError` for bare-word queries (rustledger v0.14 routes these through the compilation path).
- Broaden `test_api_query_result_error` to accept either `"Query parse error"` or `"Query compilation error"` in the response.

These changes are forward-compatible — they pass on both rustledger ≤0.13 and v0.14.

## Why

The bot-generated v0.14.0 upgrade PR (#131) is failing 4 tests against current rustledger v0.14.x because the upstream changed how it categorizes some query errors. Two of the four (`test_query_errors`, `test_query_to_file`) and one of the API tests (`test_api_query_result_error`) are pure assertion mismatches and can be loosened on `main` ahead of the upgrade.

The 4th failing test (`test_api_errors` snapshot) is **not addressed** here — the interpolation error wording changed from `"cannot infer currency for posting to"` → `"multiple postings missing amounts for"`. That requires `pytest --snapshot-update` against a v0.14.x WASM artifact and should be folded into the upgrade PR itself.

## Test plan

- [x] Diff is forward-compatible — assertions still match v0.13.x behavior on `main`
- [ ] After v0.14.x upgrade lands, verify `test_query_errors`, `test_query_to_file`, `test_api_query_result_error` all green
- [ ] Snapshot regeneration for `test_api_errors` happens in the upgrade PR (not here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)