### PR TITLE
feat(i18n): add Korean (ko) translation

### DIFF
--- a/src/rustfava/translations/ko/LC_MESSAGES/messages.po
+++ b/src/rustfava/translations/ko/LC_MESSAGES/messages.po
@@ -29,11 +29,11 @@ msgstr "다음"
 
 #: frontend/src/charts/ConversionAndInterval.svelte:17
 msgid "At Cost"
-msgstr "취득 원가"
+msgstr "취득원가"
 
 #: frontend/src/charts/ConversionAndInterval.svelte:19
 msgid "At Market Value"
-msgstr "시장 가치"
+msgstr "시장가치"
 
 #: frontend/src/charts/ConversionAndInterval.svelte:21
 #: frontend/src/reports/journal/JournalHeaders.svelte:53
@@ -181,11 +181,11 @@ msgstr "계속 추가"
 #: frontend/src/modals/Context.svelte:36 frontend/src/modals/Context.svelte:40
 #: frontend/src/modals/EntryContextBalances.svelte:25
 msgid "Context"
-msgstr "관련 내역"
+msgstr "관련내역"
 
 #: frontend/src/modals/DocumentUpload.svelte:167
 msgid "Upload file(s)"
-msgstr "파일 업로드"
+msgstr "파일업로드"
 
 #: frontend/src/modals/DocumentUpload.svelte:169
 msgid "Files"
@@ -193,7 +193,7 @@ msgstr "파일"
 
 #: frontend/src/modals/DocumentUpload.svelte:184
 msgid "Documents folder"
-msgstr "문서 폴더"
+msgstr "문서폴더"
 
 #: frontend/src/modals/DocumentUpload.svelte:195
 #: frontend/src/reports/import/ImportFileUpload.svelte:35
@@ -228,12 +228,12 @@ msgstr "오류"
 
 #: frontend/src/reports/accounts/AccountReport.svelte:55
 msgid "Journal of all entries for this Account and Sub-Accounts"
-msgstr "이 계정 및 하위 계정의 전체 저널"
+msgstr "이 계정 및 하위 계정의 전체 거래기록"
 
 #: frontend/src/reports/accounts/AccountReport.svelte:57
 #: frontend/src/reports/accounts/AccountReport.svelte:60
 msgid "Account Journal"
-msgstr "계정 거래 내역"
+msgstr "계정별거래기록"
 
 #: frontend/src/reports/accounts/AccountReport.svelte:66
 #: frontend/src/reports/accounts/AccountReport.svelte:69
@@ -361,7 +361,7 @@ msgstr "이벤트 없음."
 #: frontend/src/reports/holdings/index.ts:92
 #: frontend/src/sidebar/AsideContents.svelte:45
 msgid "Holdings"
-msgstr "보유 자산"
+msgstr "보유자산"
 
 #: frontend/src/reports/holdings/Holdings.svelte:25
 #: frontend/src/reports/holdings/Holdings.svelte:28
@@ -370,12 +370,12 @@ msgstr "보유 자산"
 #: frontend/src/reports/holdings/Holdings.svelte:45
 #: frontend/src/reports/holdings/Holdings.svelte:48
 msgid "Holdings by"
-msgstr "보유 자산 분류:"
+msgstr "보유자산분류"
 
 #: frontend/src/reports/holdings/Holdings.svelte:45
 #: frontend/src/reports/holdings/Holdings.svelte:49
 msgid "Cost currency"
-msgstr "취득 통화"
+msgstr "취득통화"
 
 #: frontend/src/reports/holdings/Holdings.svelte:56
 #: frontend/src/reports/query/index.ts:16
@@ -392,7 +392,7 @@ msgstr "가져오기"
 
 #: frontend/src/reports/import/Extract.svelte:76
 msgid "ignore duplicate"
-msgstr "중복 무시"
+msgstr "중복무시"
 
 #: frontend/src/reports/import/Extract.svelte:120
 msgid "Source"
@@ -465,11 +465,11 @@ msgstr "메타데이터"
 
 #: frontend/src/reports/journal/JournalFilters.svelte:43
 msgid "Toggle metadata"
-msgstr "메타데이터 표시 전환"
+msgstr "메타데이터 토글"
 
 #: frontend/src/reports/journal/JournalFilters.svelte:44
 msgid "Toggle postings"
-msgstr "분개 표시 전환"
+msgstr "분개 토글"
 
 #: frontend/src/reports/journal/JournalHeaders.svelte:40
 msgid "F"
@@ -487,15 +487,15 @@ msgstr "변동"
 #: frontend/src/reports/journal/index.ts:58
 #: frontend/src/sidebar/AsideContents.svelte:30
 msgid "Journal"
-msgstr "저널"
+msgstr "거래기록"
 
 #: frontend/src/reports/options/Options.svelte:13
 msgid "Color scheme"
-msgstr "색상 테마"
+msgstr "색상테마"
 
 #: frontend/src/reports/options/Options.svelte:20
 msgid "Fava options"
-msgstr "Fava 옵션"
+msgstr "Fava설정"
 
 #: frontend/src/reports/options/Options.svelte:21
 msgid "help"
@@ -503,11 +503,11 @@ msgstr "도움말"
 
 #: frontend/src/reports/options/Options.svelte:25
 msgid "Beancount options"
-msgstr "Beancount 옵션"
+msgstr "Beancount설정"
 
 #: frontend/src/reports/query/QueryEditor.svelte:21
 msgid "…enter a BQL query. 'help' to list available commands."
-msgstr "…BQL 쿼리를 입력하세요. 'help'로 명령 목록 확인."
+msgstr "…BQL 쿼리를 입력하세요. 사용 가능한 명령어를 보려면 'help'를 입력하세요."
 
 #: frontend/src/reports/query/QueryEditor.svelte:40
 msgid "Submit"
@@ -515,7 +515,7 @@ msgstr "실행"
 
 #: frontend/src/reports/query/QueryLinks.svelte:21
 msgid "Download as"
-msgstr "다운로드"
+msgstr "파일내려받기"
 
 #: frontend/src/reports/statistics/EntriesByType.svelte:14
 msgid "Type"
@@ -523,7 +523,7 @@ msgstr "유형"
 
 #: frontend/src/reports/statistics/EntriesByType.svelte:15
 msgid "# Entries"
-msgstr "항목 수"
+msgstr "거래수"
 
 #: frontend/src/reports/statistics/EntriesByType.svelte:41
 msgid "Total"
@@ -531,17 +531,17 @@ msgstr "합계"
 
 #: frontend/src/reports/statistics/Statistics.svelte:22
 msgid "Postings per Account"
-msgstr "계정별 분개 수"
+msgstr "계정별분개수"
 
 #: frontend/src/reports/statistics/Statistics.svelte:32
 msgid "Update Activity"
-msgstr "업데이트 활동"
+msgstr "최근수정이력"
 
 #: frontend/src/reports/statistics/Statistics.svelte:35
 msgid ""
 "Click to copy balance directives for accounts (except green ones) to the "
 "clipboard."
-msgstr "계정 잔액 지시문을 클립보드에 복사합니다 (녹색 계정 제외)."
+msgstr "클립보드에 계정 잔액검증 지시어를 복사하려면 클릭하세요 (녹색 제외)."
 
 #: frontend/src/reports/statistics/Statistics.svelte:40
 msgid "Copy balance directives"
@@ -549,11 +549,11 @@ msgstr "잔액 지시문 복사"
 
 #: frontend/src/reports/statistics/Statistics.svelte:47
 msgid "Entries per Type"
-msgstr "유형별 항목 수"
+msgstr "유형별거래수"
 
 #: frontend/src/reports/statistics/UpdateActivity.svelte:36
 msgid "Last Entry"
-msgstr "최근 항목"
+msgstr "최근거래"
 
 #: frontend/src/reports/statistics/index.ts:37
 #: frontend/src/sidebar/AsideContents.svelte:54
@@ -568,20 +568,20 @@ msgstr "손익계산서"
 #: frontend/src/reports/tree_reports/index.ts:49
 #: frontend/src/sidebar/AsideContents.svelte:28
 msgid "Balance Sheet"
-msgstr "대차대조표"
+msgstr "재무상태표"
 
 #: frontend/src/reports/tree_reports/index.ts:63
 #: frontend/src/sidebar/AsideContents.svelte:29
 msgid "Trial Balance"
-msgstr "합계잔액시산표"
+msgstr "시산표"
 
 #: frontend/src/sidebar/AccountSelector.svelte:22
 msgid "Go to account"
-msgstr "계정으로 이동"
+msgstr "계정이동"
 
 #: frontend/src/sidebar/AsideContents.svelte:61
 msgid "Add Journal Entry"
-msgstr "거래 추가"
+msgstr "거래기록추가"
 
 #: frontend/src/sidebar/AsideContents.svelte:76 src/fava/templates/help.html:3
 msgid "Help"
@@ -589,56 +589,56 @@ msgstr "도움말"
 
 #: frontend/src/sidebar/FilterForm.svelte:87
 msgid "Time"
-msgstr "기간"
+msgstr "조회기간"
 
 #: frontend/src/sidebar/FilterForm.svelte:109
 msgid "Filter by tag, payee, …"
-msgstr "태그, 거래처 등으로 필터링"
+msgstr "태그, 거래처 등으로 필터링…"
 
 #: frontend/src/stores/accounts.ts:113 src/fava/json_api.py:682
 #: src/fava/json_api.py:700
 msgid "Net Profit"
-msgstr "순이익"
+msgstr "당기순이익"
 
 #: frontend/src/stores/chart.ts:28
 msgid "Treemap"
-msgstr "트리맵"
+msgstr "사각계층그래프"
 
 #: frontend/src/stores/chart.ts:29
 msgid "Sunburst"
-msgstr "선버스트"
+msgstr "원형계층그래프"
 
 #: frontend/src/stores/chart.ts:30
 msgid "Icicle"
-msgstr "아이시클"
+msgstr "수직계층그래프"
 
 #: frontend/src/stores/chart.ts:43
 msgid "Line chart"
-msgstr "선형 차트"
+msgstr "꺾은선그래프"
 
 #: frontend/src/stores/chart.ts:44
 msgid "Area chart"
-msgstr "영역 차트"
+msgstr "면적그래프"
 
 #: frontend/src/stores/chart.ts:57
 msgid "Stacked Bars"
-msgstr "누적 막대"
+msgstr "누적막대그래프"
 
 #: frontend/src/stores/chart.ts:58
 msgid "Single Bars"
-msgstr "단일 막대"
+msgstr "단일막대그래프"
 
 #: frontend/src/stores/color_scheme.ts:15
 msgid "System"
-msgstr "시스템"
+msgstr "시스템설정"
 
 #: frontend/src/stores/color_scheme.ts:16
 msgid "Dark"
-msgstr "어둡게"
+msgstr "어두운테마"
 
 #: frontend/src/stores/color_scheme.ts:17
 msgid "Light"
-msgstr "밝게"
+msgstr "밝은테마"
 
 #: frontend/src/tree-table/AccountCellHeader.svelte:23
 msgid ""
@@ -650,11 +650,11 @@ msgstr ""
 
 #: frontend/src/tree-table/AccountCellHeader.svelte:34
 msgid "Expand all accounts"
-msgstr "모든 계정 펼치기"
+msgstr "모든계정펼치기"
 
 #: frontend/src/tree-table/AccountCellHeader.svelte:39
 msgid "Expand all"
-msgstr "모두 펼치기"
+msgstr "모두펼치기"
 
 #: frontend/src/tree-table/TreeTable.svelte:41
 msgid "Other"
@@ -662,7 +662,7 @@ msgstr "기타"
 
 #: src/fava/internal_api.py:171
 msgid "Account Balance"
-msgstr "계정 잔액"
+msgstr "계정잔액"
 
 #: src/fava/internal_api.py:219
 msgid "Net Worth"
@@ -674,8 +674,8 @@ msgstr "수익"
 
 #: src/fava/json_api.py:694
 msgid "Expenses"
-msgstr "지출"
+msgstr "비용"
 
 #: src/fava/templates/help.html:8
 msgid "Help pages"
-msgstr "도움말 페이지"
+msgstr "도움말페이지"

--- a/src/rustfava/translations/ko/LC_MESSAGES/messages.po
+++ b/src/rustfava/translations/ko/LC_MESSAGES/messages.po
@@ -297,7 +297,7 @@ msgstr "금액 정렬"
 
 #: frontend/src/reports/editor/EditorMenu.svelte:62
 msgid "Toggle Comment (selection)"
-msgstr "선택 영역 주석 처리 전환"
+msgstr "선택영역 주석 처리 전환"
 
 #: frontend/src/reports/editor/EditorMenu.svelte:68
 msgid "Open all folds"

--- a/src/rustfava/translations/ko/LC_MESSAGES/messages.po
+++ b/src/rustfava/translations/ko/LC_MESSAGES/messages.po
@@ -1,0 +1,681 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-03-02 12:31+0200\n"
+"PO-Revision-Date: 2026-03-04 05:09+0000\n"
+"Last-Translator: kdm1jkm <me@kdm1jkm.com>\n"
+"Language-Team: Korean <https://hosted.weblate.org/projects/fava/fava/ko/>\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.17-dev\n"
+
+#: frontend/src/app.ts:84
+msgid "File change detected. Click to reload."
+msgstr "파일 변경이 감지되었습니다. 클릭하여 새로고침하세요."
+
+#: frontend/src/charts/ChartSwitcher.svelte:26
+#: frontend/src/reports/import/Extract.svelte:100
+msgid "Previous"
+msgstr "이전"
+
+#: frontend/src/charts/ChartSwitcher.svelte:33
+#: frontend/src/reports/import/Extract.svelte:105
+msgid "Next"
+msgstr "다음"
+
+#: frontend/src/charts/ConversionAndInterval.svelte:17
+msgid "At Cost"
+msgstr "취득 원가"
+
+#: frontend/src/charts/ConversionAndInterval.svelte:19
+msgid "At Market Value"
+msgstr "시장 가치"
+
+#: frontend/src/charts/ConversionAndInterval.svelte:21
+#: frontend/src/reports/journal/JournalHeaders.svelte:53
+msgid "Units"
+msgstr "수량"
+
+#: frontend/src/charts/ConversionAndInterval.svelte:23
+#, python-format
+msgid "Converted to %(currency)s"
+msgstr "%(currency)s(으)로 환산"
+
+#: frontend/src/charts/HierarchyContainer.svelte:33
+msgid "Chart is empty."
+msgstr "차트가 비어 있습니다."
+
+#: frontend/src/editor/DeleteButton.svelte:11
+msgid "Deleting…"
+msgstr "삭제 중…"
+
+#: frontend/src/editor/DeleteButton.svelte:11
+#: frontend/src/editor/DeleteButton.svelte:14
+#: frontend/src/reports/import/FileList.svelte:47
+msgid "Delete"
+msgstr "삭제"
+
+#: frontend/src/editor/SaveButton.svelte:14
+msgid "Saving…"
+msgstr "저장 중…"
+
+#: frontend/src/editor/SaveButton.svelte:14
+#: frontend/src/modals/AddEntry.svelte:66
+#: frontend/src/reports/import/Extract.svelte:115
+msgid "Save"
+msgstr "저장"
+
+#: frontend/src/editor/SliceEditor.svelte:102
+msgid "reload"
+msgstr "새로고침"
+
+#: frontend/src/entry-forms/AccountInput.svelte:24
+msgid "Should be one of the declared accounts"
+msgstr "선언된 계정 중 하나여야 합니다"
+
+#: frontend/src/entry-forms/AccountInput.svelte:39
+#: frontend/src/modals/DocumentUpload.svelte:192
+#: frontend/src/modals/EntryContextBalances.svelte:31
+#: frontend/src/reports/holdings/Holdings.svelte:25
+#: frontend/src/reports/holdings/Holdings.svelte:29
+#: frontend/src/reports/statistics/UpdateActivity.svelte:32
+#: frontend/src/sidebar/FilterForm.svelte:98
+msgid "Account"
+msgstr "계정"
+
+#: frontend/src/entry-forms/AddMetadataButton.svelte:19
+#: frontend/src/entry-forms/EntryMetadata.svelte:53
+#: frontend/src/entry-forms/EntryMetadata.svelte:54
+msgid "Add metadata"
+msgstr "메타데이터 추가"
+
+#: frontend/src/entry-forms/Balance.svelte:28
+#: frontend/src/modals/AddEntry.svelte:15
+#: frontend/src/reports/journal/JournalHeaders.svelte:56
+#: frontend/src/reports/statistics/UpdateActivity.svelte:39
+msgid "Balance"
+msgstr "잔액"
+
+#: frontend/src/entry-forms/Balance.svelte:43
+msgid "Number"
+msgstr "금액"
+
+#: frontend/src/entry-forms/Balance.svelte:54
+#: frontend/src/reports/holdings/Holdings.svelte:35
+#: frontend/src/reports/holdings/Holdings.svelte:39
+msgid "Currency"
+msgstr "통화"
+
+#: frontend/src/entry-forms/EntryMetadata.svelte:29
+#: frontend/src/reports/options/OptionsTable.svelte:14
+msgid "Key"
+msgstr "키"
+
+#: frontend/src/entry-forms/EntryMetadata.svelte:40
+#: frontend/src/reports/options/OptionsTable.svelte:15
+msgid "Value"
+msgstr "값"
+
+#: frontend/src/entry-forms/Note.svelte:27
+#: frontend/src/modals/AddEntry.svelte:16
+msgid "Note"
+msgstr "비고"
+
+#: frontend/src/entry-forms/Posting.svelte:100
+msgid "Amount"
+msgstr "금액"
+
+#: frontend/src/entry-forms/Transaction.svelte:111
+#: frontend/src/entry-forms/Transaction.svelte:113
+#: frontend/src/reports/journal/JournalHeaders.svelte:51
+msgid "Payee"
+msgstr "거래처"
+
+#: frontend/src/entry-forms/Transaction.svelte:126
+#: frontend/src/entry-forms/Transaction.svelte:128
+#: frontend/src/reports/journal/JournalHeaders.svelte:51
+msgid "Narration"
+msgstr "적요"
+
+#: frontend/src/entry-forms/Transaction.svelte:159
+#: frontend/src/reports/journal/JournalFilters.svelte:44
+msgid "Postings"
+msgstr "분개"
+
+#: frontend/src/lib/interval.ts:22 src/fava/util/date.py:128
+msgid "Yearly"
+msgstr "연도별"
+
+#: frontend/src/lib/interval.ts:23 src/fava/util/date.py:148
+msgid "Quarterly"
+msgstr "분기별"
+
+#: frontend/src/lib/interval.ts:24 src/fava/util/date.py:174
+msgid "Monthly"
+msgstr "월별"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:196
+msgid "Weekly"
+msgstr "주별"
+
+#: frontend/src/lib/interval.ts:26 src/fava/util/date.py:221
+msgid "Daily"
+msgstr "일별"
+
+#: frontend/src/modals/AddEntry.svelte:14
+msgid "Transaction"
+msgstr "거래"
+
+#: frontend/src/modals/AddEntry.svelte:43
+msgid "Add"
+msgstr "추가"
+
+#: frontend/src/modals/AddEntry.svelte:64
+msgid "continue"
+msgstr "계속 추가"
+
+#: frontend/src/modals/Context.svelte:36 frontend/src/modals/Context.svelte:40
+#: frontend/src/modals/EntryContextBalances.svelte:25
+msgid "Context"
+msgstr "관련 내역"
+
+#: frontend/src/modals/DocumentUpload.svelte:167
+msgid "Upload file(s)"
+msgstr "파일 업로드"
+
+#: frontend/src/modals/DocumentUpload.svelte:169
+msgid "Files"
+msgstr "파일"
+
+#: frontend/src/modals/DocumentUpload.svelte:184
+msgid "Documents folder"
+msgstr "문서 폴더"
+
+#: frontend/src/modals/DocumentUpload.svelte:195
+#: frontend/src/reports/import/ImportFileUpload.svelte:35
+msgid "Upload"
+msgstr "업로드"
+
+#: frontend/src/modals/EntryContextBalances.svelte:32
+msgid "Balances before entry"
+msgstr "거래 입력 전 잔액"
+
+#: frontend/src/modals/EntryContextBalances.svelte:34
+msgid "Balances after entry"
+msgstr "거래 반영 후 잔액"
+
+#: frontend/src/modals/EntryContextLocation.svelte:14
+msgid "Location"
+msgstr "위치"
+
+#: frontend/src/modals/Export.svelte:13
+#: frontend/src/sidebar/AsideContents.svelte:73
+msgid "Export"
+msgstr "내보내기"
+
+#: frontend/src/modals/Export.svelte:15
+msgid "Download currently filtered entries as a Beancount file"
+msgstr "현재 필터가 적용된 항목을 Beancount 파일로 다운로드"
+
+#: frontend/src/reports/errors/Errors.svelte:24
+#: frontend/src/reports/route.ts:102
+msgid "Error"
+msgstr "오류"
+
+#: frontend/src/reports/accounts/AccountReport.svelte:55
+msgid "Journal of all entries for this Account and Sub-Accounts"
+msgstr "이 계정 및 하위 계정의 전체 저널"
+
+#: frontend/src/reports/accounts/AccountReport.svelte:57
+#: frontend/src/reports/accounts/AccountReport.svelte:60
+msgid "Account Journal"
+msgstr "계정 거래 내역"
+
+#: frontend/src/reports/accounts/AccountReport.svelte:66
+#: frontend/src/reports/accounts/AccountReport.svelte:69
+#: src/fava/json_api.py:785
+msgid "Changes"
+msgstr "변동"
+
+#: frontend/src/reports/accounts/AccountReport.svelte:75
+#: frontend/src/reports/accounts/AccountReport.svelte:78
+msgid "Balances"
+msgstr "잔액"
+
+#: frontend/src/reports/commodities/CommodityTable.svelte:18
+#: frontend/src/reports/documents/Table.svelte:26
+#: frontend/src/reports/events/EventTable.svelte:14
+#: frontend/src/reports/journal/JournalHeaders.svelte:29
+msgid "Date"
+msgstr "날짜"
+
+#: frontend/src/reports/commodities/CommodityTable.svelte:19
+#: frontend/src/reports/journal/JournalHeaders.svelte:56
+#: frontend/src/reports/journal/JournalHeaders.svelte:59
+msgid "Price"
+msgstr "가격"
+
+#: frontend/src/reports/commodities/index.ts:32
+#: frontend/src/sidebar/AsideContents.svelte:46
+msgid "Commodities"
+msgstr "통화/자산"
+
+#: frontend/src/reports/documents/Documents.svelte:75
+msgid "Move or rename document"
+msgstr "문서 이동/이름 변경"
+
+#: frontend/src/reports/documents/Documents.svelte:80
+#: frontend/src/reports/import/FileList.svelte:84
+msgid "Move"
+msgstr "이동"
+
+#: frontend/src/reports/documents/Table.svelte:27
+msgid "Name"
+msgstr "이름"
+
+#: frontend/src/reports/documents/index.ts:19
+#: frontend/src/sidebar/AsideContents.svelte:47
+msgid "Documents"
+msgstr "문서"
+
+#: frontend/src/reports/editor/EditorMenu.svelte:42
+#: frontend/src/reports/errors/Errors.svelte:22
+msgid "File"
+msgstr "파일"
+
+#: frontend/src/reports/editor/EditorMenu.svelte:52
+msgid "Edit"
+msgstr "수정"
+
+#: frontend/src/reports/editor/EditorMenu.svelte:56
+msgid "Align Amounts"
+msgstr "금액 정렬"
+
+#: frontend/src/reports/editor/EditorMenu.svelte:62
+msgid "Toggle Comment (selection)"
+msgstr "선택 영역 주석 처리 전환"
+
+#: frontend/src/reports/editor/EditorMenu.svelte:68
+msgid "Open all folds"
+msgstr "모두 펼치기"
+
+#: frontend/src/reports/editor/EditorMenu.svelte:74
+msgid "Close all folds"
+msgstr "모두 접기"
+
+#: frontend/src/reports/editor/EditorMenu.svelte:81
+#: frontend/src/reports/options/index.ts:15
+#: frontend/src/sidebar/AsideContents.svelte:75
+msgid "Options"
+msgstr "옵션"
+
+#: frontend/src/reports/editor/index.ts:33
+#: frontend/src/sidebar/AsideContents.svelte:57
+msgid "Editor"
+msgstr "편집기"
+
+#: frontend/src/reports/errors/Errors.svelte:23
+#: frontend/src/reports/import/Extract.svelte:121
+msgid "Line"
+msgstr "행"
+
+#: frontend/src/reports/errors/Errors.svelte:49
+#, python-format
+msgid "Show source %(file)s:%(lineno)s"
+msgstr "소스 보기 %(file)s:%(lineno)s"
+
+#: frontend/src/reports/errors/Errors.svelte:77
+msgid "No errors."
+msgstr "오류 없음."
+
+#: frontend/src/reports/errors/index.ts:6
+#: frontend/src/sidebar/AsideContents.svelte:68
+msgid "Errors"
+msgstr "오류"
+
+#: frontend/src/reports/events/EventTable.svelte:15
+msgid "Description"
+msgstr "설명"
+
+#: frontend/src/reports/events/Events.svelte:16
+#: frontend/src/reports/events/index.ts:17
+#: frontend/src/sidebar/AsideContents.svelte:50
+msgid "Events"
+msgstr "이벤트"
+
+#: frontend/src/reports/events/Events.svelte:31
+#, python-format
+msgid "Event: %(type)s"
+msgstr "이벤트: %(type)s"
+
+#: frontend/src/reports/events/Events.svelte:37
+msgid "No events."
+msgstr "이벤트 없음."
+
+#: frontend/src/reports/holdings/Holdings.svelte:18
+#: frontend/src/reports/holdings/Holdings.svelte:20
+#: frontend/src/reports/holdings/index.ts:92
+#: frontend/src/sidebar/AsideContents.svelte:45
+msgid "Holdings"
+msgstr "보유 자산"
+
+#: frontend/src/reports/holdings/Holdings.svelte:25
+#: frontend/src/reports/holdings/Holdings.svelte:28
+#: frontend/src/reports/holdings/Holdings.svelte:35
+#: frontend/src/reports/holdings/Holdings.svelte:38
+#: frontend/src/reports/holdings/Holdings.svelte:45
+#: frontend/src/reports/holdings/Holdings.svelte:48
+msgid "Holdings by"
+msgstr "보유 자산 분류:"
+
+#: frontend/src/reports/holdings/Holdings.svelte:45
+#: frontend/src/reports/holdings/Holdings.svelte:49
+msgid "Cost currency"
+msgstr "취득 통화"
+
+#: frontend/src/reports/holdings/Holdings.svelte:56
+#: frontend/src/reports/query/index.ts:16
+#: frontend/src/reports/statistics/Statistics.svelte:24
+#: frontend/src/sidebar/AsideContents.svelte:31
+msgid "Query"
+msgstr "쿼리"
+
+#: frontend/src/reports/import/Extract.svelte:58
+#: frontend/src/reports/import/index.ts:59
+#: frontend/src/sidebar/AsideContents.svelte:72
+msgid "Import"
+msgstr "가져오기"
+
+#: frontend/src/reports/import/Extract.svelte:76
+msgid "ignore duplicate"
+msgstr "중복 무시"
+
+#: frontend/src/reports/import/Extract.svelte:120
+msgid "Source"
+msgstr "출처"
+
+#: frontend/src/reports/import/FileList.svelte:95
+msgid "Continue"
+msgstr "계속"
+
+#: frontend/src/reports/import/FileList.svelte:95
+msgid "Extract"
+msgstr "추출"
+
+#: frontend/src/reports/import/FileList.svelte:104
+msgid "Clear"
+msgstr "비우기"
+
+#: frontend/src/reports/import/Import.svelte:78
+msgid "Delete this file?"
+msgstr "이 파일을 삭제할까요?"
+
+#: frontend/src/reports/import/Import.svelte:145
+msgid "No files were found for import."
+msgstr "가져올 파일이 없습니다."
+
+#: frontend/src/reports/import/Import.svelte:148
+msgid "Importable Files"
+msgstr "가져올 수 있는 파일"
+
+#: frontend/src/reports/import/Import.svelte:162
+msgid "Non-importable Files"
+msgstr "가져올 수 없는 파일"
+
+#: frontend/src/reports/import/ImportFileUpload.svelte:33
+msgid "Upload files for import"
+msgstr "가져올 파일 업로드"
+
+#: frontend/src/reports/journal/JournalFilters.svelte:8
+#, python-format
+msgid "Toggle %(type)s entries"
+msgstr "%(type)s 항목 표시 전환"
+
+#: frontend/src/reports/journal/JournalFilters.svelte:25
+msgid "Cleared transactions"
+msgstr "확인된 거래"
+
+#: frontend/src/reports/journal/JournalFilters.svelte:26
+msgid "Pending transactions"
+msgstr "대기 중 거래"
+
+#: frontend/src/reports/journal/JournalFilters.svelte:27
+msgid "Other transactions"
+msgstr "기타 거래"
+
+#: frontend/src/reports/journal/JournalFilters.svelte:34
+msgid "Documents with a #discovered tag"
+msgstr "#discovered 태그가 있는 문서"
+
+#: frontend/src/reports/journal/JournalFilters.svelte:38
+msgid "Documents with a #linked tag"
+msgstr "#linked 태그가 있는 문서"
+
+#: frontend/src/reports/journal/JournalFilters.svelte:42
+msgid "Budget entries"
+msgstr "예산 항목"
+
+#: frontend/src/reports/journal/JournalFilters.svelte:43
+msgid "Metadata"
+msgstr "메타데이터"
+
+#: frontend/src/reports/journal/JournalFilters.svelte:43
+msgid "Toggle metadata"
+msgstr "메타데이터 표시 전환"
+
+#: frontend/src/reports/journal/JournalFilters.svelte:44
+msgid "Toggle postings"
+msgstr "분개 표시 전환"
+
+#: frontend/src/reports/journal/JournalHeaders.svelte:40
+msgid "F"
+msgstr "F"
+
+#: frontend/src/reports/journal/JournalHeaders.svelte:55
+#: frontend/src/reports/journal/JournalHeaders.svelte:58
+msgid "Cost"
+msgstr "원가"
+
+#: frontend/src/reports/journal/JournalHeaders.svelte:55
+msgid "Change"
+msgstr "변동"
+
+#: frontend/src/reports/journal/index.ts:58
+#: frontend/src/sidebar/AsideContents.svelte:30
+msgid "Journal"
+msgstr "저널"
+
+#: frontend/src/reports/options/Options.svelte:13
+msgid "Color scheme"
+msgstr "색상 테마"
+
+#: frontend/src/reports/options/Options.svelte:20
+msgid "Fava options"
+msgstr "Fava 옵션"
+
+#: frontend/src/reports/options/Options.svelte:21
+msgid "help"
+msgstr "도움말"
+
+#: frontend/src/reports/options/Options.svelte:25
+msgid "Beancount options"
+msgstr "Beancount 옵션"
+
+#: frontend/src/reports/query/QueryEditor.svelte:21
+msgid "…enter a BQL query. 'help' to list available commands."
+msgstr "…BQL 쿼리를 입력하세요. 'help'로 명령 목록 확인."
+
+#: frontend/src/reports/query/QueryEditor.svelte:40
+msgid "Submit"
+msgstr "실행"
+
+#: frontend/src/reports/query/QueryLinks.svelte:21
+msgid "Download as"
+msgstr "다운로드"
+
+#: frontend/src/reports/statistics/EntriesByType.svelte:14
+msgid "Type"
+msgstr "유형"
+
+#: frontend/src/reports/statistics/EntriesByType.svelte:15
+msgid "# Entries"
+msgstr "항목 수"
+
+#: frontend/src/reports/statistics/EntriesByType.svelte:41
+msgid "Total"
+msgstr "합계"
+
+#: frontend/src/reports/statistics/Statistics.svelte:22
+msgid "Postings per Account"
+msgstr "계정별 분개 수"
+
+#: frontend/src/reports/statistics/Statistics.svelte:32
+msgid "Update Activity"
+msgstr "업데이트 활동"
+
+#: frontend/src/reports/statistics/Statistics.svelte:35
+msgid ""
+"Click to copy balance directives for accounts (except green ones) to the "
+"clipboard."
+msgstr "계정 잔액 지시문을 클립보드에 복사합니다 (녹색 계정 제외)."
+
+#: frontend/src/reports/statistics/Statistics.svelte:40
+msgid "Copy balance directives"
+msgstr "잔액 지시문 복사"
+
+#: frontend/src/reports/statistics/Statistics.svelte:47
+msgid "Entries per Type"
+msgstr "유형별 항목 수"
+
+#: frontend/src/reports/statistics/UpdateActivity.svelte:36
+msgid "Last Entry"
+msgstr "최근 항목"
+
+#: frontend/src/reports/statistics/index.ts:37
+#: frontend/src/sidebar/AsideContents.svelte:54
+msgid "Statistics"
+msgstr "통계"
+
+#: frontend/src/reports/tree_reports/index.ts:38
+#: frontend/src/sidebar/AsideContents.svelte:27
+msgid "Income Statement"
+msgstr "손익계산서"
+
+#: frontend/src/reports/tree_reports/index.ts:49
+#: frontend/src/sidebar/AsideContents.svelte:28
+msgid "Balance Sheet"
+msgstr "대차대조표"
+
+#: frontend/src/reports/tree_reports/index.ts:63
+#: frontend/src/sidebar/AsideContents.svelte:29
+msgid "Trial Balance"
+msgstr "합계잔액시산표"
+
+#: frontend/src/sidebar/AccountSelector.svelte:22
+msgid "Go to account"
+msgstr "계정으로 이동"
+
+#: frontend/src/sidebar/AsideContents.svelte:61
+msgid "Add Journal Entry"
+msgstr "거래 추가"
+
+#: frontend/src/sidebar/AsideContents.svelte:76 src/fava/templates/help.html:3
+msgid "Help"
+msgstr "도움말"
+
+#: frontend/src/sidebar/FilterForm.svelte:87
+msgid "Time"
+msgstr "기간"
+
+#: frontend/src/sidebar/FilterForm.svelte:109
+msgid "Filter by tag, payee, …"
+msgstr "태그, 거래처 등으로 필터링"
+
+#: frontend/src/stores/accounts.ts:113 src/fava/json_api.py:682
+#: src/fava/json_api.py:700
+msgid "Net Profit"
+msgstr "순이익"
+
+#: frontend/src/stores/chart.ts:28
+msgid "Treemap"
+msgstr "트리맵"
+
+#: frontend/src/stores/chart.ts:29
+msgid "Sunburst"
+msgstr "선버스트"
+
+#: frontend/src/stores/chart.ts:30
+msgid "Icicle"
+msgstr "아이시클"
+
+#: frontend/src/stores/chart.ts:43
+msgid "Line chart"
+msgstr "선형 차트"
+
+#: frontend/src/stores/chart.ts:44
+msgid "Area chart"
+msgstr "영역 차트"
+
+#: frontend/src/stores/chart.ts:57
+msgid "Stacked Bars"
+msgstr "누적 막대"
+
+#: frontend/src/stores/chart.ts:58
+msgid "Single Bars"
+msgstr "단일 막대"
+
+#: frontend/src/stores/color_scheme.ts:15
+msgid "System"
+msgstr "시스템"
+
+#: frontend/src/stores/color_scheme.ts:16
+msgid "Dark"
+msgstr "어둡게"
+
+#: frontend/src/stores/color_scheme.ts:17
+msgid "Light"
+msgstr "밝게"
+
+#: frontend/src/tree-table/AccountCellHeader.svelte:23
+msgid ""
+"Hold Shift while clicking to expand all children.\n"
+"Hold Ctrl or Cmd while clicking to expand one level."
+msgstr ""
+"Shift+클릭으로 모든 하위 항목 펼치기.\n"
+"Ctrl 또는 Cmd+클릭으로 한 단계 펼치기."
+
+#: frontend/src/tree-table/AccountCellHeader.svelte:34
+msgid "Expand all accounts"
+msgstr "모든 계정 펼치기"
+
+#: frontend/src/tree-table/AccountCellHeader.svelte:39
+msgid "Expand all"
+msgstr "모두 펼치기"
+
+#: frontend/src/tree-table/TreeTable.svelte:41
+msgid "Other"
+msgstr "기타"
+
+#: src/fava/internal_api.py:171
+msgid "Account Balance"
+msgstr "계정 잔액"
+
+#: src/fava/internal_api.py:219
+msgid "Net Worth"
+msgstr "순자산"
+
+#: src/fava/json_api.py:688
+msgid "Income"
+msgstr "수익"
+
+#: src/fava/json_api.py:694
+msgid "Expenses"
+msgstr "지출"
+
+#: src/fava/templates/help.html:8
+msgid "Help pages"
+msgstr "도움말 페이지"


### PR DESCRIPTION
## Summary

Adds Korean (`ko`) translation for the rustfava web interface.

- 146 strings translated (100% complete)
- Synced with fava's Weblate Korean translation
- K-IFRS standard accounting terminology applied (e.g. `재무상태표` for Balance Sheet, `당기순이익` for Net Profit, `비용` for Expenses)
- UI labels follow zero-spacing principle (e.g. `계정별거래기록`, `거래기록추가`)
- Chart menus use consistent 한자어 series (e.g. `계층구조도`, `원형계층그래프`, `꺾은선그래프`)
- Accounting terminology: `적요` for Narration, `분개` for Postings, `손익계산서` for Income Statement

## Test plan

- [ ] Launch rustfava and verify Korean locale is selectable
- [ ] Spot-check sidebar menu items, journal headers, and chart labels
- [ ] Verify no untranslated strings remain