### PR TITLE
fix: handle v0.16 kind-tagged cost-number wire shape

### DIFF
--- a/src/rustfava/rustledger/loader.py
+++ b/src/rustfava/rustledger/loader.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from rustfava.rustledger.engine import RustledgerEngine
 from rustfava.rustledger.options import options_from_json
+from rustfava.rustledger.types import cost_number_values
 from rustfava.rustledger.types import directives_from_json
 
 if TYPE_CHECKING:
@@ -52,7 +53,12 @@ def _compute_display_precision(entries_json: list[dict[str, Any]]) -> dict[str, 
                 track_amount(posting.get("units"))
                 if posting.get("cost"):
                     cost = posting["cost"]
-                    track_amount({"number": cost.get("number"), "currency": cost.get("currency")})
+                    per_unit, total = cost_number_values(cost.get("number"))
+                    value = per_unit if per_unit is not None else total
+                    if value is not None:
+                        track_amount(
+                            {"number": str(value), "currency": cost.get("currency")}
+                        )
                 track_amount(posting.get("price"))
 
         elif entry_type == "balance":

--- a/src/rustfava/rustledger/types.py
+++ b/src/rustfava/rustledger/types.py
@@ -90,6 +90,30 @@ class RLAmount:
         )
 
 
+def cost_number_values(
+    raw: Any,
+) -> tuple[Decimal | None, Decimal | None]:
+    """Extract ``(per_unit, total)`` from a cost's ``number`` wire value.
+
+    rustledger v0.16+ encodes the cost number as a ``kind``-tagged object
+    (its ``CostNumber`` enum: ``per_unit`` / ``total`` /
+    ``per_unit_from_total``); older releases sent a flat numeric string.
+    Returns ``(None, None)`` when there is no cost number.
+    """
+    if isinstance(raw, dict):
+        kind = raw.get("kind")
+        if kind == "per_unit":
+            return Decimal(raw["value"]), None
+        if kind == "total":
+            return None, Decimal(raw["value"])
+        if kind == "per_unit_from_total":
+            return Decimal(raw["per_unit"]), Decimal(raw["total"])
+        return None, None
+    if raw:
+        return Decimal(str(raw)), None
+    return None, None
+
+
 @dataclass(frozen=True, slots=True)
 class RLCost:
     """Rustledger Cost type."""
@@ -128,11 +152,11 @@ class RLCost:
             if data.get("date")
             else default_date
         )
-        # Handle both per-unit (number) and total cost (number_total)
-        number = Decimal(data["number"]) if data.get("number") else None
-        number_total = (
-            Decimal(data["number_total"]) if data.get("number_total") else None
-        )
+        # v0.16+ sends the cost number as a `kind`-tagged object; older
+        # releases used flat `number` / `number_total` strings.
+        number, number_total = cost_number_values(data.get("number"))
+        if number_total is None and data.get("number_total"):
+            number_total = Decimal(str(data["number_total"]))
         # If we have total cost but not per-unit, compute per-unit
         if number is None and number_total is not None and units_number:
             number = number_total / abs(units_number)


### PR DESCRIPTION
Fixes rustfava's `main`, which went red on `test-py-typeguard` after the v0.16.0 bump (#151).

**Root cause:** rustledger v0.16 changed the FFI-WASI **cost number** from flat `number`/`number_total` strings to a `kind`-tagged object (its `CostNumber` enum: `per_unit` / `total` / `per_unit_from_total`). rustfava still did `Decimal(cost["number"])`, raising `TypeError: conversion from dict to Decimal is not supported` for any posting with a cost annotation — which broke ledger loading entirely (hence the 7 failures + 164 collection errors).

**Fix:**
- `types.py`: new `cost_number_values()` that extracts `(per_unit, total)` from the tagged object, with a fallback to the legacy flat-string shape; used in `RLCost.from_json`.
- `loader.py`: same helper for cost-precision tracking (it was feeding the raw dict into the precision counter).

Verified the helper against all three v0.16 kinds + legacy + None, and both modules compile. Couldn't run the full pytest locally (build backend needs `bun`), so CI does the integration check against the real v0.16 WASM — `test-py-typeguard` should now pass.

This is a symptom fix; the **root brittleness** (FFI-WASI wire format changing between releases, breaking every rustfava bump) is being looked at separately under rustledger#1384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)