### PR TITLE
test(query): regression for inventory cost-lot summing (#155)

### DIFF
--- a/tests/test_rustledger_query.py
+++ b/tests/test_rustledger_query.py
@@ -12,6 +12,7 @@ import datetime
 from decimal import Decimal
 
 from rustfava.beans import create
+from rustfava.rustledger.query import _convert_row_value
 from rustfava.rustledger.query import _entries_to_source
 from rustfava.rustledger.types import RLCustom
 from rustfava.rustledger.types import RLCustomValue
@@ -132,3 +133,39 @@ def test_entries_to_source_skips_fava_custom_directives() -> None:
 
     assert "fava-option" not in source
     assert "budget" in source
+
+
+_INVENTORY_COL = {"name": "balance", "datatype": "Inventory"}
+
+
+def test_inventory_sums_same_currency_cost_lots() -> None:
+    """Regression for https://github.com/rustledger/rustfava/issues/155.
+
+    Now that the serializer preserves cost basis, a balances query returns
+    several positions of the same currency at different cost lots. Flattening
+    the inventory to ``{currency: number}`` must accumulate; the old
+    assignment kept only the last lot (e.g. 60 ITOT collapsed to 2).
+    """
+    value = {
+        "positions": [
+            {"units": {"number": "2", "currency": "ITOT"}},
+            {"units": {"number": "3", "currency": "ITOT"}},
+        ]
+    }
+
+    assert _convert_row_value(value, _INVENTORY_COL) == {"ITOT": Decimal("5")}
+
+
+def test_inventory_mixed_currencies_and_lots() -> None:
+    value = {
+        "positions": [
+            {"units": {"number": "2", "currency": "ITOT"}},
+            {"units": {"number": "3", "currency": "ITOT"}},
+            {"units": {"number": "100.00", "currency": "USD"}},
+        ]
+    }
+
+    assert _convert_row_value(value, _INVENTORY_COL) == {
+        "ITOT": Decimal("5"),
+        "USD": Decimal("100.00"),
+    }


### PR DESCRIPTION
Adds the regression test for the inventory cost-lot summing bug (root-caused and fixed in #145, commit c66329c4).

## What

Two unit tests on `_convert_row_value` asserting that an `Inventory` query value with multiple positions of the same currency at different cost lots is flattened by **accumulating** per currency, not overwriting. The old `result[currency] = Decimal(number)` kept only the last lot — collapsing e.g. `60 ITOT` to `2` on the long-example ledger.

## Why a unit test on `_convert_row_value`

Fast, no engine/wasm dependency. Verified it's a true regression test, not just a passing assertion:

- With the fix (current `main`): passes.
- With the fix reverted to the old assignment: fails with `{'ITOT': Decimal('3')} != {'ITOT': Decimal('5')}` — the exact production symptom (collapse to the last lot).

## Scope

Part of #155 — satisfies **acceptance criterion 1** (regression test) only. Deliberately **not** closing the issue: criterion 2 (unify the `query.py` sum vs `query_shell.py` list representations) and criterion 3 (decide whether cost-lot detail should survive the flatten) are design decisions left open.

Test-only change; no production code touched.
