### PR TITLE
fix(query): unify inventory rendering in query export (#155 criterion 2)

### DIFF
--- a/src/rustfava/core/query_shell.py
+++ b/src/rustfava/core/query_shell.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import shlex
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from rustfava.core.module_base import FavaModule
@@ -269,14 +270,19 @@ def _numberify_rows(
                 # Amount-like
                 new_row.append(f"{value.number} {value.currency}")
             elif isinstance(value, dict):
-                # Inventory or other dict
-                if "positions" in value:
-                    # Inventory
-                    parts = []
-                    for pos in value.get("positions", []):
-                        units = pos.get("units", {})
-                        parts.append(f"{units.get('number', '')} {units.get('currency', '')}")
-                    new_row.append(", ".join(parts))
+                # Inventory. The cursor layer (query._convert_row_value) is the
+                # single place that interprets the engine's {"positions": [...]}
+                # payload, flattening it to {currency: Decimal} (summing cost
+                # lots). Render that canonical form here as "<number> <currency>"
+                # parts, matching the Amount case above and comma-joining
+                # multi-currency inventories (sorted for stable output).
+                if value and all(isinstance(v, Decimal) for v in value.values()):
+                    new_row.append(
+                        ", ".join(
+                            f"{number} {currency}"
+                            for currency, number in sorted(value.items())
+                        )
+                    )
                 else:
                     new_row.append(str(value))
             elif isinstance(value, (list, set, frozenset)):

--- a/tests/__snapshots__/test_core_query_shell-test_query_to_file
+++ b/tests/__snapshots__/test_core_query_shell-test_query_to_file
@@ -1,31 +1,23 @@
-(b"account,balance\r\nAssets:US:BofA:Checking,{'USD': Decimal('502.25')}\r\nAss"
- b"ets:US:ETrade:Cash,{'USD': Decimal('8689.74')}\r\nAssets:US:ETrade:GLD,{'G"
- b"LD': Decimal('10')}\r\nAssets:US:ETrade:ITOT,{'ITOT': Decimal('60')}\r\nAsse"
- b"ts:US:ETrade:VEA,{'VEA': Decimal('4')}\r\nAssets:US:ETrade:VHT,{'VHT': Dec"
- b"imal('23')}\r\nAssets:US:Federal:PreTax401k,{'IRAUSD': Decimal('0.00')}\r\nA"
- b"ssets:US:Hoogle:Vacation,{'VACHR': Decimal('130')}\r\nAssets:US:Vanguard:C"
- b"ash,{'USD': Decimal('0.04')}\r\nAssets:US:Vanguard:RGAGX,{'RGAGX': Decimal"
- b"('103.322')}\r\nAssets:US:Vanguard:VBMPX,{'VBMPX': Decimal('63.276')}\r\nEqu"
- b"ity:Opening-Balances,{'USD': Decimal('-4363.28')}\r\nExpenses:Financial:Co"
- b"mmissions,{'USD': Decimal('179.00')}\r\nExpenses:Financial:Fees,{'USD': De"
- b"cimal('48.00')}\r\nExpenses:Food:Groceries,{'USD': Decimal('2196.80')}\r\nEx"
- b"penses:Food:Restaurant,{'USD': Decimal('3795.18')}\r\nExpenses:Health:Dent"
- b"al:Insurance,{'USD': Decimal('75.40')}\r\nExpenses:Health:Life:GroupTermLi"
- b"fe,{'USD': Decimal('632.32')}\r\nExpenses:Health:Medical:Insurance,{'USD':"
- b" Decimal('711.88')}\r\nExpenses:Health:Vision:Insurance,{'USD': Decimal('1"
- b"099.80')}\r\nExpenses:Home:Electricity,{'USD': Decimal('715.00')}\r\nExpense"
- b"s:Home:Internet,{'USD': Decimal('879.86')}\r\nExpenses:Home:Phone,{'USD': "
- b"Decimal('666.23')}\r\nExpenses:Home:Rent,{'USD': Decimal('26400.00')}\r\nExp"
- b"enses:Taxes:Y2010:US:CityNYC,{'USD': Decimal('4547.92')}\r\nExpenses:Taxes"
- b":Y2010:US:Federal,{'USD': Decimal('27635.92')}\r\nExpenses:Taxes:Y2010:US:"
- b"Federal:PreTax401k,{'IRAUSD': Decimal('16500.00')}\r\nExpenses:Taxes:Y2010"
- b":US:Medicare,{'USD': Decimal('2772.12')}\r\nExpenses:Taxes:Y2010:US:SDI,{'"
- b"USD': Decimal('29.12')}\r\nExpenses:Taxes:Y2010:US:SocSec,{'USD': Decimal("
- b"'7000.04')}\r\nExpenses:Taxes:Y2010:US:State,{'USD': Decimal('9492.08')}\r\n"
- b"Expenses:Transport:Tram,{'USD': Decimal('1440.00')}\r\nIncome:US:ETrade:Di"
- b"vidends,{'USD': Decimal('-70.55')}\r\nIncome:US:ETrade:Gains,{'USD': Decim"
- b"al('-76.05')}\r\nIncome:US:Federal:PreTax401k,{'IRAUSD': Decimal('-16500')"
- b"}\r\nIncome:US:Hoogle:GroupTermLife,{'USD': Decimal('-632.32')}\r\nIncome:US"
- b":Hoogle:Match401k,{'USD': Decimal('-8250.00')}\r\nIncome:US:Hoogle:Salary,"
- b"{'USD': Decimal('-119999.88')}\r\nIncome:US:Hoogle:Vacation,{'VACHR': Deci"
- b"mal('-130')}\r\nLiabilities:US:Chase:Slate,{'USD': Decimal('-1144.44')}\r\n")
+(b'account,balance\r\nAssets:US:BofA:Checking,502.25 USD\r\nAssets:US:ETrade:Ca'
+ b'sh,8689.74 USD\r\nAssets:US:ETrade:GLD,10 GLD\r\nAssets:US:ETrade:ITOT,60 IT'
+ b'OT\r\nAssets:US:ETrade:VEA,4 VEA\r\nAssets:US:ETrade:VHT,23 VHT\r\nAssets:'
+ b'US:Federal:PreTax401k,0.00 IRAUSD\r\nAssets:US:Hoogle:Vacation,130 VACHR\r\n'
+ b'Assets:US:Vanguard:Cash,0.04 USD\r\nAssets:US:Vanguard:RGAGX,103.322 RGAGX'
+ b'\r\nAssets:US:Vanguard:VBMPX,63.276 VBMPX\r\nEquity:Opening-Balances,-4363.2'
+ b'8 USD\r\nExpenses:Financial:Commissions,179.00 USD\r\nExpenses:Financial:Fee'
+ b's,48.00 USD\r\nExpenses:Food:Groceries,2196.80 USD\r\nExpenses:Food:Restaura'
+ b'nt,3795.18 USD\r\nExpenses:Health:Dental:Insurance,75.40 USD\r\nExpenses:Hea'
+ b'lth:Life:GroupTermLife,632.32 USD\r\nExpenses:Health:Medical:Insurance,711'
+ b'.88 USD\r\nExpenses:Health:Vision:Insurance,1099.80 USD\r\nExpenses:Home:Ele'
+ b'ctricity,715.00 USD\r\nExpenses:Home:Internet,879.86 USD\r\nExpenses:Home:Ph'
+ b'one,666.23 USD\r\nExpenses:Home:Rent,26400.00 USD\r\nExpenses:Taxes:Y2010:US'
+ b':CityNYC,4547.92 USD\r\nExpenses:Taxes:Y2010:US:Federal,27635.92 USD\r\nExpe'
+ b'nses:Taxes:Y2010:US:Federal:PreTax401k,16500.00 IRAUSD\r\nExpenses:Taxes:Y'
+ b'2010:US:Medicare,2772.12 USD\r\nExpenses:Taxes:Y2010:US:SDI,29.12 USD\r\nExp'
+ b'enses:Taxes:Y2010:US:SocSec,7000.04 USD\r\nExpenses:Taxes:Y2010:US:State,9'
+ b'492.08 USD\r\nExpenses:Transport:Tram,1440.00 USD\r\nIncome:US:ETrade:Divide'
+ b'nds,-70.55 USD\r\nIncome:US:ETrade:Gains,-76.05 USD\r\nIncome:US:Federal:Pre'
+ b'Tax401k,-16500 IRAUSD\r\nIncome:US:Hoogle:GroupTermLife,-632.32 USD\r\nIncom'
+ b'e:US:Hoogle:Match401k,-8250.00 USD\r\nIncome:US:Hoogle:Salary,-119999.88 U'
+ b'SD\r\nIncome:US:Hoogle:Vacation,-130 VACHR\r\nLiabilities:US:Chase:Slate,-11'
+ b'44.44 USD\r\n')

--- a/tests/test_core_query_shell.py
+++ b/tests/test_core_query_shell.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 import pytest
@@ -12,6 +13,7 @@ from rustfava.core.query_shell import QueryCompilationError
 from rustfava.core.query_shell import QueryNotFoundError
 from rustfava.core.query_shell import QueryParseError
 from rustfava.core.query_shell import TooManyRunArgsError
+from rustfava.core.query_shell import _numberify_rows
 from rustfava.util import excel
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -131,3 +133,24 @@ def test_query_to_excel_file(get_ledger: GetRustfavaLedger) -> None:
 
     name, _data = query_shell.query_to_file(entries, "run custom_query", "ods")
     assert name == "custom_query"
+
+
+def test_numberify_rows_renders_inventory_as_amount_strings() -> None:
+    """#155 criterion 2: the export layer renders the canonical inventory
+    representation ({currency: Decimal}, produced by query._convert_row_value)
+    as "<number> <currency>" parts, sorted and comma-joined for multi-currency
+    inventories -- not the Python dict repr it used to emit.
+    """
+    rows = [
+        ({"USD": Decimal("502.25")},),
+        ({"ITOT": Decimal("60")},),
+        ({"USD": Decimal("5"), "EUR": Decimal("3")},),
+    ]
+    columns = (object(),)  # single column; branch keys off the value, not col
+
+    out = _numberify_rows(rows, columns)
+
+    assert out[0] == ("502.25 USD",)
+    assert out[1] == ("60 ITOT",)
+    # multi-currency is sorted by currency for stable output
+    assert out[2] == ("3 EUR, 5 USD",)


### PR DESCRIPTION
Resolves acceptance **criterion 2** of #155 — unify the two `positions` → display representations.

## Investigation

The two sites weren't really two *representations* — they were one canonical interpretation plus a dead branch:

- `query._convert_row_value` (cursor layer) is the single place that interprets the engine's `{"positions": [...]}` payload, flattening it to `{currency: Decimal}` (summing cost lots — the #145 fix).
- `query_shell._numberify_rows` (export layer) is only ever called with `res.fetchall()`, i.e. rows already converted by `_convert_row_value`. So its `if "positions" in value` branch was **dead code** — Inventory values arrive as `{currency: Decimal}`, never with `"positions"`, and fell through to `else: str(value)`.

The visible consequence: query exports wrote Python dict reprs into the file —

```
account,balance
Assets:US:BofA:Checking,{'USD': Decimal('502.25')}
Assets:US:ETrade:ITOT,{'ITOT': Decimal('60')}
```

## Fix

Make the export layer trust the canonical form. `_numberify_rows` now renders `{currency: Decimal}` as `"<number> <currency>"` parts (sorted, comma-joined for multi-currency), matching the `Amount` case directly above it:

```
account,balance
Assets:US:BofA:Checking,502.25 USD
Assets:US:ETrade:ITOT,60 ITOT
```

Dead `positions` branch removed; the single representation is now `{currency: Decimal}`, interpreted once in `_convert_row_value` and rendered consistently downstream.

## Tests / verification

- New unit test `test_numberify_rows_renders_inventory_as_amount_strings` (single, multi-currency-sorted).
- Regenerated the `test_query_to_file` CSV snapshot — diff is purely the repr→`"num currency"` cleanup, totals unchanged (`60 ITOT`, etc.).
- Full suite: **20 failed / 451 passed**, i.e. **0 new failures vs `main`** (the 20 are the pre-existing v0.16 compat set).

Note: this is a user-facing improvement to CSV/XLSX query export — the old `{'USD': Decimal('...')}` output was unintended repr leakage, now clean amount strings.

Part of #155 (criterion 2). Criterion 3 (whether cost-lot detail should survive the flatten at all) remains a separate open decision.
