### PR TITLE
docs(query): note inventory columns are units-only (#155 criterion 3)

### DIFF
--- a/src/rustfava/help/features.md
+++ b/src/rustfava/help/features.md
@@ -36,6 +36,16 @@ WHERE
 GROUP BY payee, account
 ```
 
+An inventory column (e.g. `SUM(position)`) shows the summed **units** held per
+currency. It does not carry per-lot cost basis, so positions of the same
+currency bought at different costs are combined into a single units total. To
+work with cost basis or market value instead, wrap the position in the
+`COST(...)` or `VALUE(...)` functions, which return an amount:
+
+```
+SELECT account, COST(SUM(position)), VALUE(SUM(position)) GROUP BY account
+```
+
 Rustfava supports downloading the result of these queries in various file formats.
 By default, only exporting to `csv` is supported. For support of `xlsx` and
 `ods`, install rustfava with the `excel` feature:

--- a/src/rustfava/rustledger/query.py
+++ b/src/rustfava/rustledger/query.py
@@ -123,7 +123,12 @@ def _convert_row_value(value: Any, column: dict[str, str]) -> Any:
         return frozenset(value)
     if datatype == "Inventory" and isinstance(value, dict):
         # Inventory comes as {"positions": [{"units": {"number": "...", "currency": "..."}}]}
-        # Convert to simpler format for Fava
+        # The FFI payload carries units only -- no per-position cost basis -- so
+        # this units-summed {currency: Decimal} form is the complete information
+        # available for an inventory column. Cost basis / market value are
+        # exposed separately via the COST()/VALUE() BQL functions (which return
+        # scalar amounts). Preserving cost lots here would require the engine to
+        # emit cost per position first; see rustledger/rustfava#155.
         positions = value.get("positions", [])
         result = {}
         for pos in positions:


### PR DESCRIPTION
Documents the inventory-column behavior for #155 acceptance **criterion 3** (option A).

An inventory query column (e.g. `SUM(position)`) shows summed **units** per currency and does not carry per-lot cost basis — the FFI engine payload is units-only, so positions of the same currency at different costs combine into one units total. This is the complete information available for an inventory column; cost basis / market value are obtained with `COST(...)` / `VALUE(...)`, which return amounts and are computed server-side.

## Changes

- **Query help** (`features.md`): user-facing note explaining the units-only inventory column and pointing to `COST()` / `VALUE()`.
- **`query.py`**: maintainer note at the flatten site recording that the payload is units-only and that preserving cost lots would require the engine to emit cost per position (tracked separately).

Docs/comment only — no behavior change. Part of #155 (criterion 3, option A). The forward-looking FFI work to *unblock* preserving cost lots (option B) is filed separately as a `rustledger` issue.
