### PR TITLE
fix(engine): validate FFI api_version on every response (#159)

### DIFF
--- a/src/rustfava/rustledger/engine.py
+++ b/src/rustfava/rustledger/engine.py
@@ -17,8 +17,12 @@ if TYPE_CHECKING:
     from typing import Any
 
 
-# Supported API version prefix
-SUPPORTED_API_VERSION = "1."
+# The major version of the rustledger FFI ``api_version`` this build of
+# rustfava understands. Minor versions are additive and backward compatible,
+# so a higher minor (e.g. 2.1 against an expected 2.0) is accepted; a different
+# major is a wire-format break and is rejected. See rustledger-ffi-wasi's
+# ``API_VERSION`` policy (major-on-break, negotiate from the response payload).
+SUPPORTED_API_MAJOR = 2
 
 # Rustledger release to download
 RUSTLEDGER_VERSION = "v0.16.0"
@@ -34,6 +38,38 @@ class RustledgerError(Exception):
 
 class RustledgerAPIVersionError(RustledgerError):
     """Incompatible API version from rustledger."""
+
+
+def _check_api_version(api_version: object) -> None:
+    """Validate the FFI ``api_version`` carried on a response.
+
+    Minor versions are additive and backward compatible, so any version that
+    shares :data:`SUPPORTED_API_MAJOR` is accepted (a higher minor such as
+    ``2.1`` against an expected ``2.0`` is fine). A different major is a
+    wire-format break and is rejected. Responses without an ``api_version``
+    (not every method returns one) are left unchecked.
+
+    Raises:
+        RustledgerAPIVersionError: If the major version is incompatible or
+            cannot be parsed.
+    """
+    if api_version is None:
+        return
+    major_token = str(api_version).split(".", 1)[0]
+    try:
+        major = int(major_token)
+    except ValueError:
+        msg = (
+            f"Unparseable rustledger API version {api_version!r}; "
+            f"this rustfava build supports {SUPPORTED_API_MAJOR}.x"
+        )
+        raise RustledgerAPIVersionError(msg) from None
+    if major != SUPPORTED_API_MAJOR:
+        msg = (
+            f"Unsupported rustledger API version {api_version!r}; "
+            f"this rustfava build supports {SUPPORTED_API_MAJOR}.x"
+        )
+        raise RustledgerAPIVersionError(msg)
 
 
 class RustledgerEngine:
@@ -175,8 +211,12 @@ class RustledgerEngine:
             message = error.get("message", "Unknown error")
             raise RustledgerError(f"[{code}] {message}")
 
-        # Return the result
-        return dict(response.get("result", {}))
+        # Validate wire compatibility, then return the result. The server
+        # reports its api_version on the response payload; refuse an
+        # incompatible major rather than failing opaquely deeper in parsing.
+        result_dict = dict(response.get("result", {}))
+        _check_api_version(result_dict.get("api_version"))
+        return result_dict
 
     def load(self, source: str, filename: str = "<stdin>") -> dict[str, Any]:
         """Load/parse beancount source and return entries, errors, options.

--- a/tests/test_rustledger_engine.py
+++ b/tests/test_rustledger_engine.py
@@ -1,0 +1,43 @@
+"""Tests for rustledger FFI api_version validation.
+
+Regression coverage for https://github.com/rustledger/rustfava/issues/159 —
+the engine previously declared a supported-version constant but never read or
+enforced ``api_version``, so any (incompatible) server version was accepted
+silently.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rustfava.rustledger.engine import _check_api_version
+from rustfava.rustledger.engine import RustledgerAPIVersionError
+from rustfava.rustledger.engine import SUPPORTED_API_MAJOR
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        None,  # responses without api_version are not checked
+        f"{SUPPORTED_API_MAJOR}.0",
+        f"{SUPPORTED_API_MAJOR}.1",  # higher minor is additive/back-compatible
+        f"{SUPPORTED_API_MAJOR}.10",
+        str(SUPPORTED_API_MAJOR),  # bare major
+    ],
+)
+def test_check_api_version_accepts_compatible(version: str | None) -> None:
+    # Must not raise.
+    _check_api_version(version)
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        f"{SUPPORTED_API_MAJOR - 1}.0",  # older major
+        f"{SUPPORTED_API_MAJOR + 1}.0",  # newer major
+        "not-a-version",  # unparseable
+    ],
+)
+def test_check_api_version_rejects_incompatible(version: str) -> None:
+    with pytest.raises(RustledgerAPIVersionError):
+        _check_api_version(version)


### PR DESCRIPTION
Closes #159.

## Problem

`engine.py` declared `SUPPORTED_API_VERSION = "1."` but **never read or enforced** `api_version` — the constant was referenced nowhere and was also stale (the server has been on major `2` since v0.16.0). So rustfava silently accepted any FFI version; a wire break would surface as an opaque parse/KeyError deep in a call rather than a clear "unsupported version".

## Fix

- Validate `api_version` once at the response boundary in `_rpc_call`: reject an incompatible **major** (a wire break) while **accepting any higher minor** (additive/backward compatible, e.g. `2.1` for a `2.0`-expecting client). Version-less responses (not every method returns one) are left unchecked.
- Replace the dead/stale `SUPPORTED_API_VERSION = "1."` with `SUPPORTED_API_MAJOR = 2`, and wire up the previously-unused `RustledgerAPIVersionError`.

This matches the rustledger-ffi-wasi `api_version` contract (major-on-break, negotiate from the response payload) — and is timely with rustledger/rustledger#1399 bumping the FFI to `2.1`.

## Tests

New `tests/test_rustledger_engine.py` covers the helper: accepts `None`, the supported major, and higher minors (`2.1`, `2.10`); rejects an older/newer major and an unparseable value.

## Verification

- `pytest tests/test_rustledger_engine.py` → 8 passed.
- Full suite unchanged: **20 failed / 460 passed** — the 20 are the pre-existing v0.16 compat set; the guard is transparent to the live wasm (`2.0` accepted), no new failures.
- `mypy` clean; ruff adds zero new findings vs `main` (the pre-existing `rustledger/` bridge baseline is unchanged — no unrelated reformatting).
