### PR TITLE
feat(rustledger): in-process Component-Model engine behind a flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,12 @@ excel =[
 beancount-compat = [
     "beancount>=2,<4",
 ]
+# Experimental in-process engine driving the rustledger WASI Preview 2 /
+# Component-Model component (rustledger #1384), selected via
+# RUSTFAVA_RUSTLEDGER_BACKEND=component. Default remains the JSON-RPC engine.
+component = [
+    "wasmtime>=45,<46",
+]
 
 [dependency-groups]
 # Building the documentation website with MkDocs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,18 @@ follow_untyped_imports = true
 module = ["markdown2.*"]
 follow_untyped_imports = true
 
+# `wasmtime` is an optional dependency (the `component` extra), not installed
+# in the type-checking environment; treat it as untyped.
+[[tool.mypy.overrides]]
+module = ["wasmtime.*"]
+ignore_missing_imports = true
+
+# The component engine marshals values across the untyped `wasmtime` FFI
+# boundary, so its public methods legitimately return `Any`.
+[[tool.mypy.overrides]]
+module = ["rustfava.rustledger.component_engine"]
+warn_return_any = false
+
 [tool.pytest.ini_options]
 # filterwarnings = "ignore:.*locked_cached_property.*deprecated:DeprecationWarning"
 testpaths = ["tests"]

--- a/src/rustfava/rustledger/__init__.py
+++ b/src/rustfava/rustledger/__init__.py
@@ -6,9 +6,31 @@ replacing beancount for parsing, validation, and querying.
 
 from __future__ import annotations
 
+import os
+from typing import Any
+
 from rustfava.rustledger.engine import RustledgerEngine
 from rustfava.rustledger.loader import load_string
 from rustfava.rustledger.loader import load_uncached
+
+
+def get_engine() -> Any:
+    """Return the engine named by ``RUSTFAVA_RUSTLEDGER_BACKEND``.
+
+    ``component`` selects the experimental in-process WASI Preview 2 /
+    Component-Model engine (needs the ``component`` extra: ``wasmtime``);
+    anything else (the default) keeps the JSON-RPC :class:`RustledgerEngine`.
+    The component module — and so ``wasmtime`` — is imported lazily, so the
+    default path keeps no extra dependency.
+    """
+    backend = os.environ.get("RUSTFAVA_RUSTLEDGER_BACKEND", "").lower()
+    if backend == "component":
+        from rustfava.rustledger.component_engine import (  # noqa: PLC0415
+            get_component_engine,
+        )
+
+        return get_component_engine()
+    return RustledgerEngine.get_instance()
 
 
 def is_encrypted_file(path: str) -> bool:
@@ -25,6 +47,7 @@ def is_encrypted_file(path: str) -> bool:
 
 __all__ = [
     "RustledgerEngine",
+    "get_engine",
     "is_encrypted_file",
     "load_string",
     "load_uncached",

--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -1,0 +1,265 @@
+"""Rustledger engine backed by the WASI Preview 2 / Component-Model component.
+
+The successor to :class:`rustfava.rustledger.engine.RustledgerEngine` (which
+spawns the ``wasmtime`` CLI with JSON-RPC over stdin/stdout). This driver loads
+``rustledger-ffi-component`` (rustledger #1384) once, in-process, via
+``wasmtime-py``'s component API and calls its **typed** exports directly — no
+subprocess per call, no hand-mirrored JSON DTOs.
+
+It is wired in behind a flag (see ``rustfava.rustledger.get_engine``); the
+JSON-RPC engine stays the default until the component ships as a release
+artifact (``publish = false`` upstream — rustledger ADR-0006 Phase 3).
+
+Results are marshalled from the component's typed `Record`/`Variant`/`list`
+values into plain Python by a generic, *type-driven* converter
+(:func:`_marshal`) that walks the component's own type metadata
+(`RecordType.fields`, `VariantType.cases`), so no per-type field lists are
+hand-maintained. Variants render as ``{"type": <case>, ...}`` (discriminated),
+mirroring the JSON-RPC surface's tagged unions.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from wasmtime import DirPerms
+from wasmtime import Engine
+from wasmtime import FilePerms
+from wasmtime import Store
+from wasmtime import WasiConfig
+from wasmtime.component import Component
+from wasmtime.component import Linker
+from wasmtime.component import ListType
+from wasmtime.component import OptionType
+from wasmtime.component import Record
+from wasmtime.component import RecordType
+from wasmtime.component import ResultType
+from wasmtime.component import TupleType
+from wasmtime.component import Variant
+from wasmtime.component import VariantType
+
+from rustfava.rustledger.engine import _check_api_version
+from rustfava.rustledger.engine import RustledgerError
+
+# The four exported WIT interfaces (package ``rustledger:ledger@2.1.0``).
+_LEDGER = "rustledger:ledger/ledger@2.1.0"
+_BUILDER = "rustledger:ledger/builder@2.1.0"
+_UTIL = "rustledger:ledger/util@2.1.0"
+_FORMAT = "rustledger:ledger/format@2.1.0"
+
+
+def _default_wasm_path() -> Path:
+    """Locate the bundled component wasm (overridable for local builds)."""
+    override = os.environ.get("RUSTLEDGER_COMPONENT_WASM")
+    if override:
+        return Path(override)
+    return Path(__file__).parent / "rustledger_ffi_component.wasm"
+
+
+def _marshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911
+    """Convert a component value into plain Python, driven by its WIT type.
+
+    `Record` -> ``dict`` of marshalled fields; `Variant` -> ``{"type": case,
+    ...}`` (the payload's fields when it is a record, else ``{"type": case,
+    "value": ...}``, or just ``{"type": case}`` for a unit case); `list` ->
+    ``list``; `option`/`result`/`tuple` unwrap; primitives pass through.
+    """
+    if isinstance(vtype, RecordType):
+        return {
+            name: _marshal(getattr(value, name), ftype)
+            for name, ftype in vtype.fields
+        }
+    if isinstance(vtype, VariantType):
+        cases = dict(vtype.cases)
+        tag = value.tag
+        payload_type = cases.get(tag)
+        if payload_type is None or value.payload is None:
+            return {"type": tag}
+        payload = _marshal(value.payload, payload_type)
+        if isinstance(payload, dict):
+            return {"type": tag, **payload}
+        return {"type": tag, "value": payload}
+    if isinstance(vtype, ListType):
+        return [_marshal(item, vtype.element) for item in value]
+    if isinstance(vtype, OptionType):
+        return None if value is None else _marshal(value, vtype.payload)
+    if isinstance(vtype, TupleType):
+        return [
+            _marshal(v, t) for v, t in zip(value, vtype.elements, strict=False)
+        ]
+    if isinstance(vtype, ResultType):
+        # Errors surface as exceptions in wasmtime-py; a plain value is Ok.
+        return value
+    # Fallback: an un-typed Record/Variant, or a primitive.
+    if isinstance(value, Record):
+        return {
+            k: getattr(value, k) for k in dir(value) if not k.startswith("_")
+        }
+    if isinstance(value, Variant):
+        return {"type": value.tag, "value": value.payload}
+    return value
+
+
+class RustledgerComponentEngine:
+    """In-process driver for the typed rustledger wasip2 component."""
+
+    def __init__(self, wasm_path: Path | None = None) -> None:
+        self._wasm_path = wasm_path or _default_wasm_path()
+        if not self._wasm_path.exists():
+            msg = (
+                f"rustledger component not found at {self._wasm_path}. Build "
+                "it with: cargo build -p rustledger-ffi-component "
+                "--target wasm32-wasip2 --release"
+            )
+            raise RustledgerError(msg)
+        self._engine = Engine()
+        self._component = Component.from_file(
+            self._engine,
+            str(self._wasm_path),
+        )
+        # Shared instance for source-based calls (load/query/validate/...);
+        # the component holds no cross-call state for these. ``load_full``
+        # builds a fresh instance with a pre-opened dir.
+        self._store, self._inst = self._instantiate()
+        self._iface_cache: dict[str, Any] = {}
+        self._version_checked = False
+
+    # -- instantiation -----------------------------------------------------
+
+    def _instantiate(
+        self,
+        preopen: tuple[str, str] | None = None,
+    ) -> tuple[Store, Any]:
+        store = Store(self._engine)
+        wasi = WasiConfig()
+        wasi.inherit_stdout()
+        wasi.inherit_stderr()
+        if preopen is not None:
+            host, guest = preopen
+            wasi.preopen_dir(
+                host,
+                guest,
+                DirPerms.READ_ONLY,
+                FilePerms.READ_ONLY,
+            )
+        store.set_wasi(wasi)
+        linker = Linker(self._engine)
+        linker.add_wasip2()
+        inst = linker.instantiate(store, self._component)
+        return store, inst
+
+    def _iface(self, name: str) -> Any:
+        idx = self._iface_cache.get(name)
+        if idx is None:
+            idx = self._component.get_export_index(name)
+            self._iface_cache[name] = idx
+        return idx
+
+    # -- typed calls -------------------------------------------------------
+
+    def _call(self, iface: str, func_name: str, args: list[Any]) -> Any:
+        """Call ``iface.func_name(*args)`` on the shared instance."""
+        return self._call_on(self._store, self._inst, iface, func_name, args)
+
+    def _call_on(
+        self,
+        store: Store,
+        inst: Any,
+        iface: str,
+        func_name: str,
+        args: list[Any],
+    ) -> Any:
+        """Call a func on a specific store/instance, marshalling the result."""
+        fidx = self._component.get_export_index(func_name, self._iface(iface))
+        func = inst.get_func(store, fidx)
+        raw = func(store, *args)
+        return _marshal(raw, func.type(store).result)
+
+    def _ensure_version(self) -> None:
+        if self._version_checked:
+            return
+        _check_api_version(self._call(_LEDGER, "version", []))
+        self._version_checked = True
+
+    # -- public API (mirrors RustledgerEngine) -----------------------------
+
+    def version(self) -> str:
+        """Return the component's ``api_version`` string (e.g. ``"2.1"``)."""
+        return self._call(_LEDGER, "version", [])
+
+    def load(self, source: str, filename: str = "<stdin>") -> dict[str, Any]:  # noqa: ARG002
+        """Parse + book ``source``; returns entries/errors/options/...."""
+        self._ensure_version()
+        return self._call(_LEDGER, "load", [source])
+
+    def query(self, source: str, query_string: str) -> dict[str, Any]:
+        """Run a BQL query over ``source``; returns columns/rows/errors."""
+        self._ensure_version()
+        return self._call(_LEDGER, "query", [source, query_string])
+
+    def validate(self, source: str) -> dict[str, Any]:
+        """Validate ``source``; returns ``valid`` + ``errors``."""
+        self._ensure_version()
+        return self._call(_LEDGER, "validate", [source])
+
+    def format_entries(self, source: str) -> str:
+        """Canonically reformat beancount ``source``."""
+        self._ensure_version()
+        return self._call(_FORMAT, "format-source", [source])
+
+    def get_account_type(self, account: str) -> str:
+        """Return the lowercased root type of ``account`` (or ``unknown``)."""
+        return self._call(_UTIL, "get-account-type", [account])
+
+    def is_encrypted(self, filepath: str) -> bool:
+        """Return whether ``filepath`` looks like a ``.gpg``/``.asc`` file."""
+        return self._call(_UTIL, "is-encrypted", [filepath])
+
+    def load_full(
+        self,
+        path: str,
+        *,
+        allow_unrestricted_includes: bool = False,
+        plugins: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Load a file (resolving includes/plugins) via the component.
+
+        Unlike the source-based calls this needs filesystem access, so it runs
+        on a fresh instance with the file's directory pre-opened into the WASI
+        sandbox at ``/work`` and the path rewritten accordingly.
+
+        Note: only the entry file's own directory tree is granted to the WASI
+        sandbox, so ``include`` targets must live at or below it — cross-tree
+        (``../``) includes are unreachable here regardless of
+        ``allow_unrestricted_includes`` (WASI denies the access before the
+        loader's path-security check applies). A wider pre-open root would be
+        needed to support them.
+        """
+        self._ensure_version()
+        host_path = Path(path).resolve()
+        guest_path = f"/work/{host_path.name}"
+        store, inst = self._instantiate(
+            preopen=(str(host_path.parent), "/work"),
+        )
+        return self._call_on(
+            store,
+            inst,
+            _LEDGER,
+            "load-file",
+            [guest_path, allow_unrestricted_includes, plugins or []],
+        )
+
+
+_INSTANCE: RustledgerComponentEngine | None = None
+
+
+def get_component_engine(
+    wasm_path: Path | None = None,
+) -> RustledgerComponentEngine:
+    """Return the process-wide singleton component engine."""
+    global _INSTANCE  # noqa: PLW0603
+    if _INSTANCE is None:
+        _INSTANCE = RustledgerComponentEngine(wasm_path)
+    return _INSTANCE

--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -21,6 +21,7 @@ mirroring the JSON-RPC surface's tagged unions.
 from __future__ import annotations
 
 import os
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -58,31 +59,84 @@ def _default_wasm_path() -> Path:
     return Path(__file__).parent / "rustledger_ffi_component.wasm"
 
 
-def _marshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911
+def _snake(name: str) -> str:
+    """WIT identifiers are kebab-case; the JSON-RPC surface is snake_case."""
+    return name.replace("-", "_")
+
+
+def _is_pair_list(vtype: Any) -> bool:
+    """Whether ``vtype`` is ``list<tuple<_, _>>`` (WIT's string-keyed map)."""
+    return (
+        isinstance(vtype, ListType)
+        and isinstance(vtype.element, TupleType)
+        and len(vtype.element.elements) == 2
+    )
+
+
+def _unwrap_meta_value(value: Any) -> Any:
+    """Flatten a marshalled ``meta-value`` variant to its scalar/plain form.
+
+    User metadata values are a ``meta-value`` variant (text/number/boolean/
+    amount/...). The JSON-RPC surface emitted them as plain scalars (or, for
+    amounts, a bare ``{number, currency}`` object), not discriminated unions —
+    so unwrap to match. (Directive and query-cell variants stay tagged.)
+    """
+    if isinstance(value, dict) and "type" in value:
+        if set(value) == {"type", "value"}:
+            return value["value"]
+        return {k: v for k, v in value.items() if k != "type"}
+    return value
+
+
+def _marshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911, PLR0912
     """Convert a component value into plain Python, driven by its WIT type.
 
-    `Record` -> ``dict`` of marshalled fields; `Variant` -> ``{"type": case,
-    ...}`` (the payload's fields when it is a record, else ``{"type": case,
-    "value": ...}``, or just ``{"type": case}`` for a unit case); `list` ->
-    ``list``; `option`/`result`/`tuple` unwrap; primitives pass through.
+    Output matches the JSON-RPC engine's shapes so the same downstream
+    (``loader``/``types``/``options``) parses both backends identically:
+
+    - `Record` -> ``dict`` with **snake_case** keys (WIT names are kebab-case).
+      A ``user`` field (``meta``'s user-metadata map) is **flattened** into the
+      parent, mirroring the JSON-RPC ``Meta``'s ``#[serde(flatten)]``.
+    - `Variant` -> ``{"type": <snake case>, ...}`` (discriminated; record
+      payloads spread, other payloads under ``"value"``, unit cases bare).
+    - `list<tuple<string, V>>` -> ``dict`` (WIT has no map type; the JSON-RPC
+      surface emitted these — ``display-precision``, ``meta.user``, … — as
+      objects). Other lists -> ``list``.
+    - `option`/`result`/`tuple` unwrap; `enum`/primitives pass through.
     """
     if isinstance(vtype, RecordType):
-        return {
-            name: _marshal(getattr(value, name), ftype)
-            for name, ftype in vtype.fields
-        }
+        out: dict[str, Any] = {}
+        for name, ftype in vtype.fields:
+            marshalled = _marshal(getattr(value, name), ftype)
+            if name == "user" and isinstance(marshalled, dict):
+                # `meta.user` carries arbitrary user metadata; the JSON-RPC
+                # `Meta` flattened it into the meta object (scalar values), so
+                # do the same.
+                out.update(
+                    {k: _unwrap_meta_value(v) for k, v in marshalled.items()}
+                )
+            else:
+                out[_snake(name)] = marshalled
+        return out
     if isinstance(vtype, VariantType):
         cases = dict(vtype.cases)
         tag = value.tag
         payload_type = cases.get(tag)
+        out_tag = _snake(tag)
         if payload_type is None or value.payload is None:
-            return {"type": tag}
+            return {"type": out_tag}
         payload = _marshal(value.payload, payload_type)
         if isinstance(payload, dict):
-            return {"type": tag, **payload}
-        return {"type": tag, "value": payload}
+            return {"type": out_tag, **payload}
+        return {"type": out_tag, "value": payload}
     if isinstance(vtype, ListType):
-        return [_marshal(item, vtype.element) for item in value]
+        items = [_marshal(item, vtype.element) for item in value]
+        if _is_pair_list(vtype) and all(
+            isinstance(p, list) and len(p) == 2 and isinstance(p[0], str)
+            for p in items
+        ):
+            return {p[0]: p[1] for p in items}
+        return items
     if isinstance(vtype, OptionType):
         return None if value is None else _marshal(value, vtype.payload)
     if isinstance(vtype, TupleType):
@@ -90,15 +144,23 @@ def _marshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911
             _marshal(v, t) for v, t in zip(value, vtype.elements, strict=False)
         ]
     if isinstance(vtype, ResultType):
-        # Errors surface as exceptions in wasmtime-py; a plain value is Ok.
-        return value
-    # Fallback: an un-typed Record/Variant, or a primitive.
+        # `result<ok, err>` lifts to a Variant(tag="ok"|"err"); wasmtime-py
+        # does NOT raise. Surface `err` as an exception, unwrap `ok`.
+        if value.tag == "err":
+            err = _marshal(value.payload, vtype.err) if vtype.err else None
+            msg = str(err) if err is not None else "component error"
+            raise RustledgerError(msg)
+        return _marshal(value.payload, vtype.ok) if vtype.ok else None
+    # Fallback: an un-typed Record/Variant, an enum (lifts to str), or a
+    # primitive.
     if isinstance(value, Record):
         return {
-            k: getattr(value, k) for k in dir(value) if not k.startswith("_")
+            _snake(k): getattr(value, k)
+            for k in dir(value)
+            if not k.startswith("_")
         }
     if isinstance(value, Variant):
-        return {"type": value.tag, "value": value.payload}
+        return {"type": _snake(value.tag), "value": value.payload}
     return value
 
 
@@ -125,6 +187,11 @@ class RustledgerComponentEngine:
         self._store, self._inst = self._instantiate()
         self._iface_cache: dict[str, Any] = {}
         self._version_checked = False
+        # The shared store/instance is reused across source-based calls and
+        # wasmtime's `Store` is not concurrency-safe; serialize access since
+        # Fava serves requests on multiple threads. (`load_full` uses a fresh
+        # per-call instance and needs no lock.)
+        self._lock = threading.Lock()
 
     # -- instantiation -----------------------------------------------------
 
@@ -160,8 +227,11 @@ class RustledgerComponentEngine:
     # -- typed calls -------------------------------------------------------
 
     def _call(self, iface: str, func_name: str, args: list[Any]) -> Any:
-        """Call ``iface.func_name(*args)`` on the shared instance."""
-        return self._call_on(self._store, self._inst, iface, func_name, args)
+        """Call ``iface.func_name(*args)`` on the shared instance (locked)."""
+        with self._lock:
+            return self._call_on(
+                self._store, self._inst, iface, func_name, args
+            )
 
     def _call_on(
         self,
@@ -190,7 +260,11 @@ class RustledgerComponentEngine:
         return self._call(_LEDGER, "version", [])
 
     def load(self, source: str, filename: str = "<stdin>") -> dict[str, Any]:  # noqa: ARG002
-        """Parse + book ``source``; returns entries/errors/options/...."""
+        """Parse + book ``source``; returns entries/errors/options/....
+
+        ``filename`` is accepted for API parity with the JSON-RPC engine; the
+        WIT ``load(source)`` has no filename param, so it is unused here.
+        """
         self._ensure_version()
         return self._call(_LEDGER, "load", [source])
 

--- a/tests/test_rustledger_component_engine.py
+++ b/tests/test_rustledger_component_engine.py
@@ -1,0 +1,96 @@
+"""Smoke tests for the experimental Component-Model engine (rustledger #1384).
+
+Skipped unless ``wasmtime`` is installed *and* the wasip2 component artifact is
+locatable (bundled next to the engine, or via ``RUSTLEDGER_COMPONENT_WASM``).
+Build the component with::
+
+    cargo build -p rustledger-ffi-component --target wasm32-wasip2 --release
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+pytest.importorskip("wasmtime")
+
+if TYPE_CHECKING:
+    from rustfava.rustledger.component_engine import RustledgerComponentEngine
+
+
+def _component_available() -> bool:
+    from rustfava.rustledger.component_engine import (  # noqa: PLC0415
+        _default_wasm_path,
+    )
+
+    return _default_wasm_path().exists()
+
+
+pytestmark = pytest.mark.skipif(
+    not _component_available(),
+    reason="rustledger wasip2 component artifact not found",
+)
+
+
+@pytest.fixture(scope="module")
+def engine() -> RustledgerComponentEngine:
+    from rustfava.rustledger.component_engine import (  # noqa: PLC0415
+        RustledgerComponentEngine,
+    )
+
+    return RustledgerComponentEngine()
+
+
+SRC = (
+    "2024-01-01 open Assets:Cash USD\n"
+    "2024-01-01 open Expenses:Food USD\n"
+    '2024-01-02 * "Coffee"\n'
+    "  Expenses:Food  5 USD\n"
+    "  Assets:Cash\n"
+)
+
+
+def test_version(engine: RustledgerComponentEngine) -> None:
+    assert engine.version() == "2.1"
+
+
+def test_load_marshals_typed_directives(
+    engine: RustledgerComponentEngine,
+) -> None:
+    result = engine.load(SRC)
+    assert set(result) >= {"entries", "errors", "options"}
+    assert len(result["entries"]) == 3
+    assert result["errors"] == []
+    # The generic marshaller renders the directive variant as a tagged dict.
+    txn = next(e for e in result["entries"] if e["type"] == "transaction")
+    assert txn["narration"] == "Coffee"
+    assert len(txn["postings"]) == 2
+
+
+def test_query(engine: RustledgerComponentEngine) -> None:
+    result = engine.query(SRC, "SELECT account, position")
+    assert [c["name"] for c in result["columns"]] == ["account", "position"]
+    assert len(result["rows"]) >= 1
+    # Each cell is a discriminated ``{"type": ...}`` value.
+    assert result["rows"][0][0]["type"] == "text"
+
+
+def test_get_account_type(engine: RustledgerComponentEngine) -> None:
+    assert engine.get_account_type("Assets:Cash") == "assets"
+    assert engine.get_account_type("Frobnicate:X") == "unknown"
+
+
+def test_load_full_resolves_includes(
+    engine: RustledgerComponentEngine,
+) -> None:
+    with tempfile.TemporaryDirectory() as d:
+        Path(d, "sub.bean").write_text("2024-01-01 open Assets:Bank USD\n")
+        Path(d, "main.bean").write_text(
+            'include "sub.bean"\n2024-01-02 open Expenses:Rent USD\n',
+        )
+        result = engine.load_full(str(Path(d, "main.bean")))
+    assert result["errors"] == []
+    assert len(result["entries"]) >= 2  # include resolved over WASI preopen

--- a/tests/test_rustledger_component_engine.py
+++ b/tests/test_rustledger_component_engine.py
@@ -11,21 +11,20 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 
 pytest.importorskip("wasmtime")
 
-if TYPE_CHECKING:
-    from rustfava.rustledger.component_engine import RustledgerComponentEngine
+# Imported after `importorskip` so the module skips cleanly when the optional
+# `wasmtime` dependency is absent (the component engine imports it eagerly).
+from rustfava.rustledger.component_engine import _default_wasm_path
+from rustfava.rustledger.component_engine import RustledgerComponentEngine
+from rustfava.rustledger.options import options_from_json
+from rustfava.rustledger.types import directives_from_json
 
 
 def _component_available() -> bool:
-    from rustfava.rustledger.component_engine import (  # noqa: PLC0415
-        _default_wasm_path,
-    )
-
     return _default_wasm_path().exists()
 
 
@@ -37,10 +36,6 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture(scope="module")
 def engine() -> RustledgerComponentEngine:
-    from rustfava.rustledger.component_engine import (  # noqa: PLC0415
-        RustledgerComponentEngine,
-    )
-
     return RustledgerComponentEngine()
 
 
@@ -94,3 +89,51 @@ def test_load_full_resolves_includes(
         result = engine.load_full(str(Path(d, "main.bean")))
     assert result["errors"] == []
     assert len(result["entries"]) >= 2  # include resolved over WASI preopen
+
+
+# Source with multi-word WIT fields that exercise the marshaller's kebab->snake
+# key mapping, the list<tuple>->map conversion, and meta-user flattening.
+SRC_RICH = (
+    'option "operating_currency" "USD"\n'
+    "2024-01-01 open Assets:Cash USD\n"
+    "2024-01-01 open Expenses:Food USD\n"
+    '2024-01-02 * "Cafe" "Coffee"\n'
+    '  category: "dining"\n'
+    "  Expenses:Food  5 USD\n"
+    "  Assets:Cash\n"
+    '2024-01-03 custom "fava-option" "indent" "2"\n'
+)
+
+
+def test_options_marshal_parses_downstream(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """``options`` must use snake_case keys and map shapes that
+    ``options_from_json`` accepts (kebab keys / list<tuple> would crash it)."""
+    result = engine.load(SRC_RICH)
+    opts = result["options"]
+    # snake_case key (WIT field is ``operating-currency``).
+    assert opts["operating_currency"] == ["USD"]
+    # ``display-precision`` is a WIT list<tuple<string,u32>> -> must marshal to
+    # a dict so ``options_from_json``'s ``.items()`` does not raise.
+    assert isinstance(opts.get("display_precision", {}), dict)
+    # The whole object must round-trip through the real downstream parser.
+    parsed = options_from_json(opts)
+    assert "USD" in parsed["operating_currency"]
+
+
+def test_entries_marshal_parse_downstream(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """Marshalled entries must parse via ``directives_from_json`` and carry
+    flattened user metadata (the JSON-RPC ``meta`` shape)."""
+    result = engine.load(SRC_RICH)
+    entries = list(directives_from_json(result["entries"]))
+    assert entries  # parses without KeyError
+
+    txn = next(e for e in result["entries"] if e["type"] == "transaction")
+    # meta.user is flattened into meta (not nested under a "user" key).
+    assert txn["meta"]["category"] == "dining"
+    assert "user" not in txn["meta"]
+    # multi-word fields survive as snake_case where present.
+    assert "lineno" in txn["meta"]

--- a/uv.lock
+++ b/uv.lock
@@ -1414,6 +1414,9 @@ dependencies = [
 beancount-compat = [
     { name = "beancount" },
 ]
+component = [
+    { name = "wasmtime" },
+]
 excel = [
     { name = "pyexcel" },
     { name = "pyexcel-ods3" },
@@ -1478,10 +1481,11 @@ requires-dist = [
     { name = "pyexcel", marker = "extra == 'excel'", specifier = ">=0.5" },
     { name = "pyexcel-ods3", marker = "extra == 'excel'", specifier = ">=0.5" },
     { name = "pyexcel-xlsx", marker = "extra == 'excel'", specifier = ">=0.5" },
+    { name = "wasmtime", marker = "extra == 'component'", specifier = ">=45,<46" },
     { name = "watchfiles", specifier = ">=0.20.0" },
     { name = "werkzeug", specifier = ">=2.2,<4" },
 ]
-provides-extras = ["excel", "beancount-compat"]
+provides-extras = ["excel", "beancount-compat", "component"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1646,6 +1650,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/0e/933bacb37b57ae7928b0030eef205a3dbb3e37afdbdde5be2e113318958f/virtualenv-21.5.0.tar.gz", hash = "sha256:98847aadf5e2037e0e4d2e19528eb3aca6f23906422e59a510bff231a6d32fce", size = 4577424, upload-time = "2026-06-13T20:36:45.066Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/87/b0667ede418386ab631e48924b845d326f366d61e6bd08fe68a748fae4d4/virtualenv-21.5.0-py3-none-any.whl", hash = "sha256:8f7c38605023688c89789f566959006af6d61c99eeeb9e58342eb780c5761e5e", size = 4557937, upload-time = "2026-06-13T20:36:42.967Z" },
+]
+
+[[package]]
+name = "wasmtime"
+version = "45.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ff/db9cfc61d988bc15303134bb174176a29839976876dfd18c3a12548ad291/wasmtime-45.0.0.tar.gz", hash = "sha256:2ad4bf7ca286ceea35c1e420d10b368d7f83faf9a5ffde87b4ee334a9b7f55f3", size = 128297, upload-time = "2026-05-26T17:57:39.131Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/56/7d941adba273210dcf4198266a47f472a5eeca20172005b443af71a9a3e7/wasmtime-45.0.0-py3-none-android_26_arm64_v8a.whl", hash = "sha256:4e843795b53e66c71313f2254731467372e5e1549227cf14accb9e2d57701c10", size = 8659052, upload-time = "2026-05-26T17:57:12.338Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/81/c4d81ebf3db8aa28f789a9569640f30790d5234c509a0234cd502aa2638b/wasmtime-45.0.0-py3-none-android_26_x86_64.whl", hash = "sha256:35e713f907264e470f3bc9b592b81b8ed0f8f5651725d9f07a5d52beb0642e38", size = 9619373, upload-time = "2026-05-26T17:57:14.979Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c7/7594da7fa8a3bc5e765733ad57aac9b7b27262c4afa47521bd500e4a4574/wasmtime-45.0.0-py3-none-any.whl", hash = "sha256:6251ee5074a8b8bfaa98e6e99cb5d49d6d0f2320b3265d5aa6c2ee5df5fb4519", size = 8019034, upload-time = "2026-05-26T17:57:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/75/76/7d0e440ca03a717a97889dbb7b68f952c20ed4ffd3f59addf9553579e1d5/wasmtime-45.0.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:3579b0ec6d001750d66ec7089aaeee2c048f88328c82743e15f099af01b0cf84", size = 9401625, upload-time = "2026-05-26T17:57:22.149Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0b/a81b5daf5adea482ecb68d9615f6a348486ab4d8e980a915d4420e57ee4d/wasmtime-45.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:31d10f25c330cebcfb364e9a357123deeec96c41725ff2bba91b705587f38a93", size = 8255954, upload-time = "2026-05-26T17:57:24.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8c/e9019a28e908214031310aefd78e4755221d02303190b54b2c85cb69573e/wasmtime-45.0.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:5d1416ec6da8cd87c29e2e9eb074358c91839c2fff971fe428c8921eaae68e73", size = 9681185, upload-time = "2026-05-26T17:57:26.641Z" },
+    { url = "https://files.pythonhosted.org/packages/42/56/ed5f492bd553a31c8e28d621f8256f2c7b1a133b28f73525d96ca355891a/wasmtime-45.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:a499f6ab0eebb70dca83d6a4904b743cd122f322af3abe86af08ad753533d946", size = 8582001, upload-time = "2026-05-26T17:57:28.883Z" },
+    { url = "https://files.pythonhosted.org/packages/62/12/9b41740da83f51014b88181c9086de0ed75d736a5329baff7323c4fb6eff/wasmtime-45.0.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bef65282b7de744106a91da43e4d06ba19d2d587bc54abb83b3e757f0c4fc030", size = 8633462, upload-time = "2026-05-26T17:57:31.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/63/49d8317706a108d9ed1d4166d0fc710796da1b20e591a98a96575dec367a/wasmtime-45.0.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a0b6ca14b4628a5d1ffa91ccf2c0f2c58fa171f126ec085d564b09d5795395dd", size = 9712524, upload-time = "2026-05-26T17:57:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/8e31ea472ceb934e7261ac59a786e82cd82b4d4dcb7c870d498aa9c3c21e/wasmtime-45.0.0-py3-none-win_amd64.whl", hash = "sha256:1736a70a48f713aaf1a878514d29cc6f554213b5431e04447813a3b9b4320381", size = 8019039, upload-time = "2026-05-26T17:57:36.04Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d1/ac536e92ac95a02e137be5b6829f15b87d5eef93ace32e5ee8035155b839/wasmtime-45.0.0-py3-none-win_arm64.whl", hash = "sha256:ae9726590e6d90c6305b8b507c93468b145204d4390aa9a2e29e26babcae110e", size = 6845659, upload-time = "2026-05-26T17:57:37.696Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds an **experimental, flag-gated** rustledger engine that drives the typed
WASI Preview 2 / Component-Model component (`rustledger-ffi-component`,
[rustledger #1384](https://github.com/rustledger/rustledger/issues/1384))
in-process via `wasmtime-py` — the successor to the current JSON-RPC engine,
which spawns the `wasmtime` CLI once per call and exchanges hand-mirrored JSON
DTOs over stdin/stdout.

## What's here

- **`RustledgerComponentEngine`** (`src/rustfava/rustledger/component_engine.py`)
  loads the component once, instantiates it with WASI p2, and calls the typed
  `ledger` / `util` / `format` exports directly (no JSON envelope, no
  subprocess). It mirrors `RustledgerEngine`'s surface: `version`, `load`,
  `query`, `validate`, `format_entries`, `get_account_type`, `is_encrypted`,
  `load_full`.
- A **generic, type-driven marshaller** (`_marshal`) converts the component's
  typed `Record`/`Variant`/`list` values into plain Python dicts/lists by
  walking the component's *own* type metadata (`RecordType.fields`,
  `VariantType.cases`). Variants render as discriminated `{"type": <case>, ...}`
  (mirroring the JSON-RPC tagged unions), so there are **no hand-maintained
  per-type field lists**.
- **`get_engine()`** (`rustfava.rustledger`) selects the backend via
  `RUSTFAVA_RUSTLEDGER_BACKEND=component`; the default stays the JSON-RPC engine.
  The component module — and therefore `wasmtime` — is imported **lazily**, so
  the default path gains no new dependency. `wasmtime` is a new optional
  `component` extra.

## Why now (and why behind a flag)

This is the consumer-migration proof for the rustledger Component-Model work.
The component is still `publish = false` upstream (rustledger ADR-0006 Phase 3),
so rustfava can't ship against a released artifact yet — but the in-process
typed-host path is now **proven end-to-end**, ready to flip on when it releases.
The in-process model also removes the per-call subprocess cost and the JSON DTO
drift.

## Testing

`tests/test_rustledger_component_engine.py` covers version / load (typed
directive marshalling) / query / account-type / `load_full` (include resolution
over a WASI pre-open). They **skip** unless `wasmtime` is installed *and* the
wasip2 artifact is locatable (`RUSTLEDGER_COMPONENT_WASM` or bundled). Build it
with:

```
cargo build -p rustledger-ffi-component --target wasm32-wasip2 --release
```

- Component tests: 5 passed (against a local build).
- Default path unaffected: existing engine tests pass, and importing
  `rustfava.rustledger` pulls in no `wasmtime`.
- `ruff check` + `ruff format` clean.

## Follow-ups (not in scope here)

- Bundle the component `.wasm` and flip the default once it's a release artifact.
- `load_full` currently pre-opens only the entry file's directory tree, so
  cross-tree (`../`) includes are unreachable; a wider pre-open root would lift
  that (documented in the method).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
