### PR TITLE
chore: fix pre-existing mypy errors (lint-python-types)

### DIFF
--- a/src/rustfava/rustledger/query.py
+++ b/src/rustfava/rustledger/query.py
@@ -130,7 +130,7 @@ def _convert_row_value(value: Any, column: dict[str, str]) -> Any:
         # scalar amounts). Preserving cost lots here would require the engine to
         # emit cost per position first; see rustledger/rustfava#155.
         positions = value.get("positions", [])
-        result = {}
+        result: dict[str, Decimal] = {}
         for pos in positions:
             units = pos.get("units", {})
             currency = units.get("currency", "")

--- a/tests/test_core_query_shell.py
+++ b/tests/test_core_query_shell.py
@@ -8,12 +8,12 @@ import pytest
 
 from rustfava.core.query import QueryResultTable
 from rustfava.core.query import QueryResultText
+from rustfava.core.query_shell import _numberify_rows
 from rustfava.core.query_shell import NonExportableQueryError
 from rustfava.core.query_shell import QueryCompilationError
 from rustfava.core.query_shell import QueryNotFoundError
 from rustfava.core.query_shell import QueryParseError
 from rustfava.core.query_shell import TooManyRunArgsError
-from rustfava.core.query_shell import _numberify_rows
 from rustfava.util import excel
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -141,7 +141,7 @@ def test_numberify_rows_renders_inventory_as_amount_strings() -> None:
     as "<number> <currency>" parts, sorted and comma-joined for multi-currency
     inventories -- not the Python dict repr it used to emit.
     """
-    rows = [
+    rows: list[tuple[object, ...]] = [
         ({"USD": Decimal("502.25")},),
         ({"ITOT": Decimal("60")},),
         ({"USD": Decimal("5"), "EUR": Decimal("3")},),

--- a/tests/test_rustledger_query.py
+++ b/tests/test_rustledger_query.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import datetime
 from decimal import Decimal
+from typing import cast
+from typing import TYPE_CHECKING
 
 from rustfava.beans import create
 from rustfava.rustledger.query import _convert_row_value
@@ -17,6 +19,11 @@ from rustfava.rustledger.query import _entries_to_source
 from rustfava.rustledger.types import RLCustom
 from rustfava.rustledger.types import RLCustomValue
 from rustfava.rustledger.types import RLOpen
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from rustfava.beans.abc import Directive
 
 
 def test_entries_to_source_preserves_transaction_tags_links_and_metadata() -> None:
@@ -107,7 +114,10 @@ def test_entries_to_source_preserves_open_booking_method() -> None:
         booking="STRICT",
     )
 
-    source = _entries_to_source([opn])
+    # rustledger ``RL*`` directives are a parallel hierarchy to ``abc.Directive``
+    # that ``_entries_to_source``/``to_string`` accept via singledispatch
+    # duck-typing; cast to satisfy the static signature.
+    source = _entries_to_source(cast("Sequence[Directive]", [opn]))
 
     assert "open Assets:US:Brokerage" in source
     assert '"STRICT"' in source
@@ -129,7 +139,9 @@ def test_entries_to_source_skips_fava_custom_directives() -> None:
         values=(RLCustomValue("Expenses:Food", dtype=str),),
     )
 
-    source = _entries_to_source([fava_custom, other_custom])
+    source = _entries_to_source(
+        cast("Sequence[Directive]", [fava_custom, other_custom])
+    )
 
     assert "fava-option" not in source
     assert "budget" in source


### PR DESCRIPTION
Resolves the 5 pre-existing `lint-python-types` (mypy) failures on `main` — the advisory job has been red independent of recent PRs. After this, `just mypy` reports **Success: no issues found in 112 source files**.

## Changes

- **`query.py`** — annotate the per-currency accumulator `result: dict[str, Decimal]` (mypy couldn't infer the empty-dict type).
- **`test_core_query_shell.py`** — annotate the `_numberify_rows` input as `list[tuple[object, ...]]`; `list` is invariant, so the literal otherwise infers the narrower `list[tuple[dict[str, Decimal]]]` and fails the `arg-type` check. (ruff also re-sorted a pre-existing unsorted import block in this file.)
- **`test_rustledger_query.py`** — `cast` the rustledger `RL*` directives passed to `_entries_to_source` to `Sequence[Directive]`. The `RL*` types are a parallel hierarchy that the singledispatch `to_string` accepts via duck-typing but are **not** `abc.Directive` subtypes statically; the cast documents the supported duck-typed path without loosening the production signature.

## Testing

- `just mypy` → Success (0 errors)
- `just test-py` → 480 passed, **100% coverage**
- Affected tests (`test_rustledger_query`, `test_core_query_shell`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)