### PR TITLE
feat(component-engine): auto-download the released component wasm

### DIFF
--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -21,7 +21,9 @@ mirroring the JSON-RPC surface's tagged unions.
 from __future__ import annotations
 
 import os
+import sys
 import threading
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +44,7 @@ from wasmtime.component import Variant
 from wasmtime.component import VariantType
 
 from rustfava.rustledger.engine import _check_api_version
+from rustfava.rustledger.engine import RUSTLEDGER_VERSION
 from rustfava.rustledger.engine import RustledgerError
 
 # The four exported WIT interfaces (package ``rustledger:ledger@2.1.0``).
@@ -51,12 +54,47 @@ _UTIL = "rustledger:ledger/util@2.1.0"
 _FORMAT = "rustledger:ledger/format@2.1.0"
 
 
+_COMPONENT_WASM_URL = (
+    "https://github.com/rustledger/rustledger/releases/download/"
+    f"{RUSTLEDGER_VERSION}/rustledger-ffi-component-{RUSTLEDGER_VERSION}.wasm"
+)
+
+
 def _default_wasm_path() -> Path:
-    """Locate the bundled component wasm (overridable for local builds)."""
+    """Return the component wasm location (env override, else the cache path).
+
+    Does not download — that happens lazily in ``RustledgerComponentEngine``
+    so existence checks (e.g. test gating) stay side-effect free.
+    """
     override = os.environ.get("RUSTLEDGER_COMPONENT_WASM")
     if override:
         return Path(override)
     return Path(__file__).parent / "rustledger_ffi_component.wasm"
+
+
+def _download_component_wasm(wasm_path: Path) -> None:
+    """Download the released component wasm to ``wasm_path``, best-effort.
+
+    The artifact (``rustledger-ffi-component-<version>.wasm``) is attached to
+    the rustledger GitHub release matching :data:`RUSTLEDGER_VERSION`. Releases
+    that predate the component artifact return 404; on any failure this logs
+    and leaves no file behind, so the caller surfaces a clear build-from-source
+    error instead of a cryptic one.
+    """
+    print(  # noqa: T201
+        f"Downloading rustledger component wasm ({RUSTLEDGER_VERSION})...",
+        file=sys.stderr,
+    )
+    try:
+        wasm_path.parent.mkdir(parents=True, exist_ok=True)
+        urllib.request.urlretrieve(_COMPONENT_WASM_URL, wasm_path)  # noqa: S310
+        print("Done.", file=sys.stderr)  # noqa: T201
+    except Exception as e:  # noqa: BLE001
+        wasm_path.unlink(missing_ok=True)
+        print(  # noqa: T201
+            f"Could not download component wasm: {e}",
+            file=sys.stderr,
+        )
 
 
 def _snake(name: str) -> str:
@@ -169,11 +207,20 @@ class RustledgerComponentEngine:
 
     def __init__(self, wasm_path: Path | None = None) -> None:
         self._wasm_path = wasm_path or _default_wasm_path()
+        # Auto-download only the default cache location — never an explicit
+        # path or an `RUSTLEDGER_COMPONENT_WASM` override (caller-managed).
+        uses_default = wasm_path is None and not os.environ.get(
+            "RUSTLEDGER_COMPONENT_WASM",
+        )
+        if uses_default and not self._wasm_path.exists():
+            _download_component_wasm(self._wasm_path)
         if not self._wasm_path.exists():
             msg = (
-                f"rustledger component not found at {self._wasm_path}. Build "
-                "it with: cargo build -p rustledger-ffi-component "
-                "--target wasm32-wasip2 --release"
+                f"rustledger component wasm not found at {self._wasm_path} "
+                "and could not be downloaded (the pinned release may predate "
+                "the component artifact). Build it with: cargo build -p "
+                "rustledger-ffi-component --target wasm32-wasip2 --release, "
+                "or set RUSTLEDGER_COMPONENT_WASM to a local build."
             )
             raise RustledgerError(msg)
         self._engine = Engine()

--- a/tests/test_rustledger_component_engine.py
+++ b/tests/test_rustledger_component_engine.py
@@ -18,8 +18,10 @@ pytest.importorskip("wasmtime")
 
 # Imported after `importorskip` so the module skips cleanly when the optional
 # `wasmtime` dependency is absent (the component engine imports it eagerly).
+from rustfava.rustledger import component_engine
 from rustfava.rustledger.component_engine import _default_wasm_path
 from rustfava.rustledger.component_engine import RustledgerComponentEngine
+from rustfava.rustledger.engine import RustledgerError
 from rustfava.rustledger.options import options_from_json
 from rustfava.rustledger.types import directives_from_json
 
@@ -137,3 +139,26 @@ def test_entries_marshal_parse_downstream(
     assert "user" not in txn["meta"]
     # multi-word fields survive as snake_case where present.
     assert "lineno" in txn["meta"]
+
+
+def test_missing_wasm_download_fallback_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A missing wasm whose download fails surfaces a clear build-from-source
+    error (e.g. when the pinned release predates the component artifact)."""
+    monkeypatch.delenv("RUSTLEDGER_COMPONENT_WASM", raising=False)
+    missing = tmp_path / "absent.wasm"
+    monkeypatch.setattr(
+        component_engine,
+        "_default_wasm_path",
+        lambda: missing,
+    )
+    # Simulate a failed/404 download that leaves no file behind.
+    monkeypatch.setattr(
+        component_engine,
+        "_download_component_wasm",
+        lambda _p: None,
+    )
+    with pytest.raises(RustledgerError, match="wasm32-wasip2"):
+        component_engine.RustledgerComponentEngine()


### PR DESCRIPTION
## What

Wires the experimental component backend to **download the rustledger component wasm** from the matching GitHub release — the rustfava counterpart to [rustledger #1410](https://github.com/rustledger/rustledger/pull/1410) (which adds `rustledger-ffi-component-<version>.wasm` to the release pipeline).

Mirrors how `engine.py` already fetches `rustledger-ffi-wasi-<version>.wasm` for the default JSON-RPC engine.

## Details

- `_download_component_wasm` fetches `rustledger-ffi-component-<version>.wasm`, reusing **`RUSTLEDGER_VERSION`** so the wasi and component engines stay version-locked.
- `__init__` auto-downloads **only** the default cache location — an explicit `wasm_path` or `RUSTLEDGER_COMPONENT_WASM` override is left caller-managed.
- **Best-effort / graceful**: releases predating the component artifact return 404, so a failed download logs, leaves no file behind, and the engine raises a clear *build-from-source* error rather than a cryptic one.
- `_default_wasm_path` stays side-effect-free (no network) so existence checks / test gating don't download.
- Added a test for the missing-wasm → failed-download → clear-error path.

## Status

This **activates once rustfava pins a rustledger release that ships the component wasm** (i.e. the first release after #1410 merges). Until then it's dormant behind `RUSTFAVA_RUSTLEDGER_BACKEND=component`, and the download 404s gracefully. The default JSON-RPC path is unaffected.

## Testing

- `just test-py` → 488 passed (480 + 8 component tests run locally with the artifact; they skip in default CI), 100% coverage.
- Component tests verified against a locally-built wasip2 component.
- ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)