### PR TITLE
feat(component): add clamp_entries to the component engine

### DIFF
--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -117,6 +117,49 @@ def _pair_value_type(vtype: Any) -> Any:
     return vtype.element.elements[1]
 
 
+# The WIT ``cost-number`` variant. rustledger's JSON surface tags this one by
+# ``kind`` (``#[serde(tag = "kind")]`` on ``CostNumber``), not by the generic
+# ``type`` the marshaller uses for every other variant — and ``per-unit-from-
+# total`` spreads its two values as ``per_unit``/``total`` rather than a
+# ``value`` tuple. `types.py`'s ``cost_number_values`` reads exactly that
+# shape, so the cost basis is silently dropped if we emit the generic form.
+_COST_NUMBER_CASES = frozenset({"per-unit", "total", "per-unit-from-total"})
+
+
+def _is_cost_number(vtype: Any) -> bool:
+    """Whether ``vtype`` is the WIT ``cost-number`` variant."""
+    return isinstance(vtype, VariantType) and (
+        frozenset(name for name, _ in vtype.cases) == _COST_NUMBER_CASES
+    )
+
+
+def _cost_number_to_json(value: Any, vtype: Any) -> dict[str, Any]:
+    """Marshal a ``cost-number`` to the ``kind``-tagged JSON-RPC shape."""
+    payload = _marshal(value.payload, dict(vtype.cases)[value.tag])
+    kind = _snake(value.tag)
+    if value.tag == "per-unit-from-total":
+        per_unit, total = payload
+        return {"kind": kind, "per_unit": per_unit, "total": total}
+    return {"kind": kind, "value": payload}
+
+
+def _cost_number_from_json(value: Any) -> Any:
+    """Rebuild a ``cost-number`` Variant from the JSON-RPC / `types.py` shape.
+
+    Accepts what the real caller passes: ``_cost_to_json`` emits a flat
+    per-unit string, while component-marshalled input carries the
+    ``kind``-tagged dict.
+    """
+    if isinstance(value, dict):
+        kind = value.get("kind") or value.get("type")
+        tag = _kebab(str(kind))
+        if tag == "per-unit-from-total":
+            return Variant(tag, (str(value["per_unit"]), str(value["total"])))
+        return Variant(tag, str(value["value"]))
+    # A bare scalar (``_cost_to_json``'s flat string) is a per-unit cost.
+    return Variant("per-unit", str(value))
+
+
 def _unwrap_meta_value(value: Any) -> Any:
     """Flatten a marshalled ``meta-value`` variant to its scalar/plain form.
 
@@ -163,6 +206,8 @@ def _marshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911, PLR0912
                 out[_snake(name)] = marshalled
         return out
     if isinstance(vtype, VariantType):
+        if _is_cost_number(vtype):
+            return _cost_number_to_json(value, vtype)
         cases = dict(vtype.cases)
         tag = value.tag
         payload_type = cases.get(tag)
@@ -293,6 +338,8 @@ def _unmarshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911
             )
         return rec
     if isinstance(vtype, VariantType):
+        if _is_cost_number(vtype):
+            return _cost_number_from_json(value)
         cases = dict(vtype.cases)
         tag = _kebab(value["type"])
         if tag not in cases:  # tolerate an already-kebab tag

--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -24,6 +24,7 @@ import os
 import sys
 import threading
 import urllib.request
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
@@ -109,6 +110,11 @@ def _is_pair_list(vtype: Any) -> bool:
         and isinstance(vtype.element, TupleType)
         and len(vtype.element.elements) == 2
     )
+
+
+def _pair_value_type(vtype: Any) -> Any:
+    """The value type ``V`` of a ``list<tuple<string, V>>`` (a WIT map)."""
+    return vtype.element.elements[1]
 
 
 def _unwrap_meta_value(value: Any) -> Any:
@@ -199,6 +205,117 @@ def _marshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911, PLR0912
         }
     if isinstance(value, Variant):
         return {"type": _snake(value.tag), "value": value.payload}
+    return value
+
+
+def _kebab(name: str) -> str:
+    """Inverse of :func:`_snake`: snake_case (JSON-RPC) -> WIT kebab-case."""
+    return name.replace("_", "-")
+
+
+def _meta_value_json(value: Any) -> dict[str, Any]:
+    """Re-tag an unwrapped user-metadata scalar as a ``meta-value`` variant.
+
+    Inverse of :func:`_unwrap_meta_value`, mirroring rustledger's
+    ``json_to_meta_value`` (``types/input.rs``) so the reconstruction matches
+    what the JSON-RPC ``entry.clamp`` does on the Rust side: ``str`` -> text,
+    ``bool`` -> boolean, ``int``/``float``/``Decimal`` -> number, ``None`` ->
+    null, ``{number, currency}`` -> amount, anything else -> null.
+    """
+    if isinstance(value, bool):  # before int — bool is an int subclass
+        return {"type": "boolean", "value": value}
+    if isinstance(value, str):
+        return {"type": "text", "value": value}
+    if isinstance(value, (int, float, Decimal)):
+        return {"type": "number", "value": str(value)}
+    if (
+        isinstance(value, dict)
+        and value.get("number") is not None
+        and value.get("currency") is not None
+    ):
+        return {
+            "type": "amount",
+            "number": str(value["number"]),
+            "currency": value["currency"],
+        }
+    return {"type": "null"}
+
+
+def _default_for(vtype: Any) -> Any:
+    """A benign default for a record field absent from the input dict."""
+    if isinstance(vtype, OptionType):
+        return None
+    if isinstance(vtype, ListType):
+        return []
+    if isinstance(vtype, RecordType):
+        return _unmarshal({}, vtype)
+    return None
+
+
+def _unmarshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911
+    """Convert plain Python into a typed component value (inverse of _marshal).
+
+    Takes a value in :func:`_marshal`'s output shape and rebuilds the typed
+    component value of type ``vtype``.
+    Used for builder inputs: ``filter``/``clamp`` take ``list<directive>``, the
+    same type ``load`` returns, so the entries Fava already holds round-trip
+    back into the component. Records become :class:`wasmtime.component.Record`
+    (fields set by their WIT name); tagged dicts become
+    :class:`wasmtime.component.Variant`; the flattened ``meta.user`` keys are
+    re-nested and re-tagged via :func:`_meta_value_json`.
+    """
+    if isinstance(vtype, RecordType):
+        rec = Record()
+        src = value if isinstance(value, dict) else {}
+        non_user = {_snake(n) for n, _ in vtype.fields if n != "user"}
+        for name, ftype in vtype.fields:
+            if name == "user":
+                # The keys `_marshal` flattened in (everything that isn't a
+                # known `meta` field): re-nest as user metadata entries.
+                mv_type = _pair_value_type(ftype)
+                setattr(
+                    rec,
+                    name,
+                    [
+                        (k, _unmarshal(_meta_value_json(v), mv_type))
+                        for k, v in src.items()
+                        if k not in non_user
+                    ],
+                )
+                continue
+            key = _snake(name)
+            setattr(
+                rec,
+                name,
+                _unmarshal(src[key], ftype)
+                if key in src
+                else _default_for(ftype),
+            )
+        return rec
+    if isinstance(vtype, VariantType):
+        cases = dict(vtype.cases)
+        tag = _kebab(value["type"])
+        if tag not in cases:  # tolerate an already-kebab tag
+            tag = value["type"]
+        payload_type = cases[tag]
+        if payload_type is None:
+            return Variant(tag)
+        if isinstance(payload_type, RecordType):
+            payload = {k: v for k, v in value.items() if k != "type"}
+            return Variant(tag, _unmarshal(payload, payload_type))
+        return Variant(tag, _unmarshal(value["value"], payload_type))
+    if isinstance(vtype, ListType):
+        if _is_pair_list(vtype) and isinstance(value, dict):
+            vt = _pair_value_type(vtype)
+            return [(k, _unmarshal(v, vt)) for k, v in value.items()]
+        return [_unmarshal(item, vtype.element) for item in value]
+    if isinstance(vtype, OptionType):
+        return None if value is None else _unmarshal(value, vtype.payload)
+    if isinstance(vtype, TupleType):
+        return tuple(
+            _unmarshal(v, t)
+            for v, t in zip(value, vtype.elements, strict=False)
+        )
     return value
 
 
@@ -371,6 +488,50 @@ class RustledgerComponentEngine:
             "load-file",
             [guest_path, allow_unrestricted_includes, plugins or []],
         )
+
+    def clamp_entries(
+        self,
+        entries_json: list[dict[str, Any]],
+        begin_date: str,
+        end_date: str,
+    ) -> dict[str, Any]:
+        """Clamp already-loaded entries to ``[begin, end)``.
+
+        Mirrors :meth:`RustledgerEngine.clamp_entries`: synthesizes
+        opening-balance and summary directives at the window boundaries. The
+        entries are the same ``directive`` shape ``load`` emits, so they are
+        marshalled back into typed component values via :func:`_unmarshal`
+        before the call (the JSON-RPC engine instead ships the JSON and lets
+        the Rust side reconstruct — same result, different layer).
+        """
+        return {
+            "entries": self._builder_window(
+                "clamp", entries_json, begin_date, end_date
+            ),
+        }
+
+    def _builder_window(
+        self,
+        func_name: str,
+        entries_json: list[dict[str, Any]],
+        begin_date: str,
+        end_date: str,
+    ) -> list[dict[str, Any]]:
+        """Run a ``builder`` window op (``filter``/``clamp``) on entries.
+
+        Custom input marshalling means this can't reuse :meth:`_call`; it holds
+        the shared-store lock around the whole call (typed in, marshalled out).
+        """
+        self._ensure_version()
+        with self._lock:
+            fidx = self._component.get_export_index(
+                func_name, self._iface(_BUILDER)
+            )
+            func = self._inst.get_func(self._store, fidx)
+            entries_type = func.type(self._store).params[0][1]
+            wit_entries = _unmarshal(list(entries_json), entries_type)
+            raw = func(self._store, wit_entries, begin_date, end_date)
+            return _marshal(raw, func.type(self._store).result)
 
 
 _INSTANCE: RustledgerComponentEngine | None = None

--- a/tests/test_rustledger_component_engine.py
+++ b/tests/test_rustledger_component_engine.py
@@ -9,10 +9,13 @@ Build the component with::
 
 from __future__ import annotations
 
+import json
 import tempfile
 from pathlib import Path
 
 import pytest
+
+from rustfava.rustledger.engine import RustledgerEngine
 
 pytest.importorskip("wasmtime")
 
@@ -139,6 +142,96 @@ def test_entries_marshal_parse_downstream(
     assert "user" not in txn["meta"]
     # multi-word fields survive as snake_case where present.
     assert "lineno" in txn["meta"]
+
+
+# Two transactions either side of a clamp window, the in-window one carrying
+# user metadata, a tag/link, and a posting cost — the round-trip's hard cases.
+SRC_CLAMP = (
+    "2023-01-01 open Assets:Cash USD\n"
+    "2023-01-01 open Expenses:Food USD\n"
+    '2023-06-15 * "Old"\n'
+    "  Expenses:Food  5 USD\n"
+    "  Assets:Cash\n"
+    '2024-02-10 * "Coffee" #tag ^link\n'
+    '  category: "groceries"\n'
+    "  rank: 3\n"
+    "  Expenses:Food  7 USD {2 USD}\n"
+    "  Assets:Cash  -14 USD\n"
+)
+_CLAMP_BEGIN, _CLAMP_END = "2024-01-01", "2024-12-31"
+
+
+def test_clamp_entries_round_trips_directives(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """``clamp_entries`` marshals already-loaded directives back into the
+    component (via ``_unmarshal``) and preserves metadata, tags, and cost."""
+    entries = engine.load(SRC_CLAMP)["entries"]
+    clamped = engine.clamp_entries(entries, _CLAMP_BEGIN, _CLAMP_END)[
+        "entries"
+    ]
+
+    # The in-window transaction survives, with user metadata, tag/link, and
+    # the posting cost intact through the dict -> typed -> dict round-trip.
+    coffee = next(e for e in clamped if e.get("narration") == "Coffee")
+    assert coffee["meta"]["category"] == "groceries"
+    # Numeric metadata round-trips as a decimal string — matching the JSON-RPC
+    # surface, which also emits `MetaValue::Number` as a string for precision.
+    assert coffee["meta"]["rank"] == "3"
+    assert coffee["tags"] == ["tag"]
+    assert coffee["links"] == ["link"]
+    cost = coffee["postings"][0]["cost"]
+    assert cost["number"] == {"type": "per_unit", "value": "2"}
+    assert cost["currency"] == "USD"
+
+    # Output still parses through the real downstream directive parser.
+    assert list(directives_from_json(clamped))
+
+
+def test_clamp_entries_synthesizes_opening_balance(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """The pre-window transaction is folded into opening-balance directives at
+    the boundary rather than appearing verbatim."""
+    entries = engine.load(SRC_CLAMP)["entries"]
+    clamped = engine.clamp_entries(entries, _CLAMP_BEGIN, _CLAMP_END)[
+        "entries"
+    ]
+
+    narrations = [
+        e.get("narration") for e in clamped if e["type"] == "transaction"
+    ]
+    assert "Old" not in narrations  # the 2023 txn is summarized, not kept
+    # Opening-balance summary directives are synthesized at the window start.
+    assert any(n == "Opening balance" for n in narrations)
+    assert all(
+        e["date"] >= _CLAMP_BEGIN
+        for e in clamped
+        if e["type"] == "transaction"
+    )
+
+
+def test_clamp_entries_matches_jsonrpc_engine() -> None:
+    """Cross-engine parity: component ``clamp_entries`` must agree with the
+    JSON-RPC engine. Skipped when the wasmtime CLI (JSON-RPC backend) is
+    unavailable — the component path is still covered by the tests above."""
+    try:
+        jsonrpc = RustledgerEngine.get_instance()
+        jr_clamped = jsonrpc.clamp_entries(
+            jsonrpc.load(SRC_CLAMP)["entries"], _CLAMP_BEGIN, _CLAMP_END
+        )["entries"]
+    except Exception as exc:  # noqa: BLE001 - CLI absence is the expected skip
+        pytest.skip(f"JSON-RPC engine unavailable: {exc}")
+
+    component = RustledgerComponentEngine()
+    co_clamped = component.clamp_entries(
+        component.load(SRC_CLAMP)["entries"], _CLAMP_BEGIN, _CLAMP_END
+    )["entries"]
+
+    def _norm(entries: object) -> str:
+        return json.dumps(entries, sort_keys=True, default=str)
+
+    assert _norm(co_clamped) == _norm(jr_clamped)
 
 
 def test_missing_wasm_download_fallback_errors(

--- a/tests/test_rustledger_component_engine.py
+++ b/tests/test_rustledger_component_engine.py
@@ -27,6 +27,7 @@ from rustfava.rustledger.component_engine import RustledgerComponentEngine
 from rustfava.rustledger.engine import RustledgerError
 from rustfava.rustledger.options import options_from_json
 from rustfava.rustledger.types import directives_from_json
+from rustfava.rustledger.types import directives_to_json
 
 
 def _component_available() -> bool:
@@ -181,11 +182,41 @@ def test_clamp_entries_round_trips_directives(
     assert coffee["tags"] == ["tag"]
     assert coffee["links"] == ["link"]
     cost = coffee["postings"][0]["cost"]
-    assert cost["number"] == {"type": "per_unit", "value": "2"}
+    # Cost number is `kind`-tagged (matching the JSON-RPC surface, which Fava's
+    # `cost_number_values` reads); emitting the generic `type` here silently
+    # drops the cost basis downstream.
+    assert cost["number"] == {"kind": "per_unit", "value": "2"}
     assert cost["currency"] == "USD"
 
     # Output still parses through the real downstream directive parser.
     assert list(directives_from_json(clamped))
+
+
+def test_clamp_entries_via_directives_to_json_preserves_cost(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """Exercise the *real* caller's path: ``core/filters.py`` feeds
+    ``directives_to_json(entries)`` (not raw ``load`` output) into
+    ``clamp_entries``. Regression for the cost-basis loss caused by the
+    ``type`` vs ``kind`` discriminator mismatch — the round-trip below dropped
+    the cost number entirely before the fix."""
+    loaded = engine.load(SRC_CLAMP)["entries"]
+    fava_entries = list(directives_from_json(loaded))
+    prod_input = directives_to_json(fava_entries)  # what filters.py passes
+
+    # The load -> from_json -> to_json chain must keep the cost number.
+    in_coffee = next(e for e in prod_input if e.get("narration") == "Coffee")
+    assert in_coffee["postings"][0]["cost"]["number"] == "2"
+
+    clamped = engine.clamp_entries(prod_input, _CLAMP_BEGIN, _CLAMP_END)[
+        "entries"
+    ]
+    coffee = next(e for e in clamped if e.get("narration") == "Coffee")
+    assert coffee["postings"][0]["cost"]["number"] == {
+        "kind": "per_unit",
+        "value": "2",
+    }
+    assert coffee["meta"]["category"] == "groceries"
 
 
 def test_clamp_entries_synthesizes_opening_balance(


### PR DESCRIPTION
First of two PRs to make the component the default rustledger backend during the dual-ship window (rustledger #1384 Phase 4). This one completes the component wrapper; a follow-up flips the default + routes the call sites.

## Why
Auditing the actual engine surface rustfava uses on its hot paths:

| method | caller | component wrapper |
|---|---|---|
| `load` / `load_full` | `loader.py` | ✅ |
| `query` | `query.py` | ✅ |
| `is_encrypted` | `core/__init__.py` | ✅ |
| **`clamp_entries`** | `core/filters.py` (date-range filtering) | ❌ → **added here** |

The component couldn't be a true drop-in default until `clamp_entries` existed — a date-filtered request would `AttributeError`.

## What
`builder.clamp`/`filter` take `list<directive>` — the *same* type `load` returns — so the already-loaded entries Fava holds must be marshalled back into typed component values. This adds **`_unmarshal`**, the type-driven inverse of `_marshal`:

- records → `wasmtime.component.Record` (fields set by WIT name)
- tagged `{"type": …}` dicts → `Variant`
- the flattened `meta.user` keys are re-nested and re-tagged via `_meta_value_json`, mirroring rustledger's `json_to_meta_value` — so the reconstruction matches what the JSON-RPC engine does on the Rust side (same result, different layer).

Verified the JSON-RPC surface also emits `MetaValue::Number` as a decimal **string** (`json!(n.to_string())`), so numeric-metadata round-trips stay in parity (no int-vs-string drift).

## Tests
- round-trip preserves user metadata, tags/links, and posting cost (the `per_unit` cost-number variant);
- opening-balance synthesis at the window boundary;
- cross-engine parity (`clamp_entries` ≡ JSON-RPC), skipped when the wasmtime CLI is unavailable.

mypy + ruff clean. Full suite: the only failures are the pre-existing `wasmtime not found` CLI-gated tests (identical with/without this change); the component tests run via in-process `wasmtime-py` and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)