### PR TITLE
fix(component): host-path mapping, typed-value shape, field defaults

### DIFF
--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -33,6 +33,7 @@ from wasmtime import Engine
 from wasmtime import FilePerms
 from wasmtime import Store
 from wasmtime import WasiConfig
+from wasmtime.component import Bool
 from wasmtime.component import Component
 from wasmtime.component import Linker
 from wasmtime.component import ListType
@@ -40,6 +41,7 @@ from wasmtime.component import OptionType
 from wasmtime.component import Record
 from wasmtime.component import RecordType
 from wasmtime.component import ResultType
+from wasmtime.component import String
 from wasmtime.component import TupleType
 from wasmtime.component import Variant
 from wasmtime.component import VariantType
@@ -143,6 +145,56 @@ def _cost_number_to_json(value: Any, vtype: Any) -> dict[str, Any]:
     return {"kind": kind, "value": payload}
 
 
+def _is_typed_value(vtype: Any) -> bool:
+    """Whether ``vtype`` is the WIT ``typed-value`` record (custom args)."""
+    return isinstance(vtype, RecordType) and (
+        frozenset(name for name, _ in vtype.fields)
+        == frozenset({"value-type", "value"})
+    )
+
+
+def _typed_value_to_json(value: Any, vtype: Any) -> dict[str, Any]:
+    """Marshal a ``typed-value`` to the JSON-RPC ``{type, value}`` shape.
+
+    rustledger's ``TypedValue`` serializes the ``value-type`` field as ``type``
+    and carries the bare value (amount as ``{number, currency}``), which Fava's
+    ``RLCustomValue.from_raw`` reads. The generic record marshalling would emit
+    ``{value_type, value: {type: ...}}`` instead.
+    """
+    fields = dict(vtype.fields)
+    value_type = _marshal(getattr(value, "value-type"), fields["value-type"])
+    payload = _marshal(value.value, fields["value"])
+    return {"type": value_type, "value": _unwrap_meta_value(payload)}
+
+
+def _typed_value_from_json(value: Any, vtype: Any) -> Any:
+    """Rebuild a ``typed-value`` Record from the ``{type, value}`` shape.
+
+    The inverse of :func:`_typed_value_to_json`, for clamp/filter inputs whose
+    ``custom`` directives carry typed argument values.
+    """
+    vt = value.get("type", "string")
+    payload = value.get("value")
+    if vt == "amount" and isinstance(payload, dict):
+        mv: dict[str, Any] = {
+            "type": "amount",
+            "number": str(payload.get("number")),
+            "currency": payload.get("currency"),
+        }
+    elif vt == "number":
+        mv = {"type": "number", "value": str(payload)}
+    elif vt == "bool":
+        mv = {"type": "boolean", "value": bool(payload)}
+    elif vt == "null" or payload is None:
+        mv = {"type": "null"}
+    else:  # string/account/currency/tag/link/date all collapse to text
+        mv = {"type": "text", "value": str(payload)}
+    rec: Any = Record()
+    setattr(rec, "value-type", str(vt))
+    rec.value = _unmarshal(mv, dict(vtype.fields)["value"])
+    return rec
+
+
 def _cost_number_from_json(value: Any) -> Any:
     """Rebuild a ``cost-number`` Variant from the JSON-RPC / `types.py` shape.
 
@@ -192,6 +244,8 @@ def _marshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911, PLR0912
     - `option`/`result`/`tuple` unwrap; `enum`/primitives pass through.
     """
     if isinstance(vtype, RecordType):
+        if _is_typed_value(vtype):
+            return _typed_value_to_json(value, vtype)
         out: dict[str, Any] = {}
         for name, ftype in vtype.fields:
             marshalled = _marshal(getattr(value, name), ftype)
@@ -287,17 +341,27 @@ def _meta_value_json(value: Any) -> dict[str, Any]:
 
 
 def _default_for(vtype: Any) -> Any:
-    """A benign default for a record field absent from the input dict."""
+    """A benign default for a record field absent from the input dict.
+
+    ``directives_to_json`` omits fields the loader fills in (e.g. the meta
+    hash); the JSON-RPC engine relies on serde defaults, so we must supply
+    type-appropriate zero values rather than ``None`` (which wasmtime rejects).
+    """
     if isinstance(vtype, OptionType):
         return None
     if isinstance(vtype, ListType):
         return []
     if isinstance(vtype, RecordType):
         return _unmarshal({}, vtype)
-    return None
+    if isinstance(vtype, String):
+        return ""
+    if isinstance(vtype, Bool):
+        return False
+    # Remaining scalars are numeric (u32 lineno, s64, floats).
+    return 0
 
 
-def _unmarshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911
+def _unmarshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911, PLR0912
     """Convert plain Python into a typed component value (inverse of _marshal).
 
     Takes a value in :func:`_marshal`'s output shape and rebuilds the typed
@@ -310,6 +374,8 @@ def _unmarshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911
     re-nested and re-tagged via :func:`_meta_value_json`.
     """
     if isinstance(vtype, RecordType):
+        if _is_typed_value(vtype):
+            return _typed_value_from_json(value, vtype)
         rec = Record()
         src = value if isinstance(value, dict) else {}
         non_user = {_snake(n) for n, _ in vtype.fields if n != "user"}
@@ -528,13 +594,36 @@ class RustledgerComponentEngine:
         store, inst = self._instantiate(
             preopen=(str(host_path.parent), "/work"),
         )
-        return self._call_on(
+        result = self._call_on(
             store,
             inst,
             _LEDGER,
             "load-file",
             [guest_path, allow_unrestricted_includes, plugins or []],
         )
+        # The component sees files under the WASI pre-open mount (``/work``),
+        # so the directives it returns carry guest paths in ``meta.filename``
+        # (and the include list). Map them back to real host paths — Fava opens
+        # these files for editing, so a ``/work/...`` path would not exist.
+        self._rewrite_guest_paths(result, host_path.parent)
+        return result
+
+    @staticmethod
+    def _rewrite_guest_paths(result: dict[str, Any], host_dir: Path) -> None:
+        """Rewrite ``/work/...`` guest paths in a load result to host paths."""
+
+        def to_host(p: Any) -> Any:
+            if isinstance(p, str) and p.startswith("/work/"):
+                return str(host_dir / p[len("/work/") :])
+            return p
+
+        for entry in result.get("entries", []):
+            meta = entry.get("meta")
+            if isinstance(meta, dict) and "filename" in meta:
+                meta["filename"] = to_host(meta["filename"])
+        for include in result.get("includes", []):
+            if isinstance(include, dict) and "path" in include:
+                include["path"] = to_host(include["path"])
 
     def clamp_entries(
         self,

--- a/tests/test_rustledger_component_engine.py
+++ b/tests/test_rustledger_component_engine.py
@@ -265,6 +265,64 @@ def test_clamp_entries_matches_jsonrpc_engine() -> None:
     assert _norm(co_clamped) == _norm(jr_clamped)
 
 
+def test_load_full_returns_host_paths(
+    engine: RustledgerComponentEngine,
+    tmp_path: Path,
+) -> None:
+    """``load_full`` must map WASI guest paths back to real host paths.
+
+    The component sees files under the ``/work`` pre-open mount; Fava opens the
+    returned ``meta.filename`` to edit entries, so a ``/work/...`` path would
+    not exist on disk (regression: file edits hit FileNotFoundError)."""
+    main = tmp_path / "main.bean"
+    main.write_text("2024-01-01 open Assets:Cash USD\n")
+    result = engine.load_full(str(main))
+
+    filenames = {e["meta"]["filename"] for e in result["entries"]}
+    assert filenames == {str(main)}
+    assert not any(f.startswith("/work") for f in filenames)
+
+
+def test_custom_typed_values_use_jsonrpc_shape(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """``custom`` directive args marshal to the JSON-RPC ``{type, value}``
+    shape (amount un-nested), which Fava's ``RLCustomValue`` reads. The generic
+    record marshalling would emit ``{value_type, value: {type: ...}}``."""
+    src = (
+        "2024-01-01 open Expenses:Groceries USD\n"
+        '2024-01-01 custom "budget" Expenses:Groceries "weekly" 100.00 USD\n'
+    )
+    custom = next(
+        e for e in engine.load(src)["entries"] if e["type"] == "custom"
+    )
+    assert custom["values"] == [
+        {"type": "account", "value": "Expenses:Groceries"},
+        {"type": "string", "value": "weekly"},
+        {"type": "amount", "value": {"number": "100.00", "currency": "USD"}},
+    ]
+
+
+def test_clamp_preserves_custom_typed_values(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """A ``custom`` directive round-trips through ``clamp_entries`` (the
+    ``typed-value`` unmarshal path) with its typed args intact."""
+    src = (
+        "2024-01-01 open Expenses:Groceries USD\n"
+        '2024-06-01 custom "budget" Expenses:Groceries "weekly" 50.00 USD\n'
+    )
+    entries = engine.load(src)["entries"]
+    clamped = engine.clamp_entries(entries, "2024-01-01", "2024-12-31")[
+        "entries"
+    ]
+    custom = next(e for e in clamped if e["type"] == "custom")
+    assert {
+        "type": "amount",
+        "value": {"number": "50.00", "currency": "USD"},
+    } in (custom["values"])
+
+
 def test_missing_wasm_download_fallback_errors(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
Three correctness fixes for the opt-in component backend, found by running Fava's **full test suite** through it for the first time (`RUSTFAVA_RUSTLEDGER_BACKEND=component`). They are independent of making the component the default (tracked separately) — each is a real bug in the component path today.

## Fixes

1. **`load_full` leaks WASI guest paths.** The component sees files under the `/work` pre-open mount, so returned directives carried `meta.filename = "/work/<file>.beancount"`. Fava opens that path to edit entries → `FileNotFoundError`. Now mapped back to real host paths (filenames + includes).

2. **`custom` typed values used the wrong shape.** The generic marshaller emitted `{value_type, value: {type: ...}}`, but rustledger's `TypedValue` serializes as `{type, value}` (amount un-nested as `{number, currency}`) — which Fava's `RLCustomValue.from_raw` reads. This broke budget / fava-option / extension parsing. Fixed in both directions (`_marshal` + the `_unmarshal` inverse for the clamp/filter round-trip).

3. **Omitted required fields became `None`.** `directives_to_json` omits fields the loader fills (e.g. the meta hash); the JSON-RPC engine relies on serde defaults. `_default_for` now supplies type-appropriate zeros (`""` / `0` / `False`) instead of `None` (which wasmtime rejects).

## Impact

Running the full suite through the component went from **114 failures → 21** (and 164 fixture-setup cascade errors → 0) with these three fixes plus the already-merged cost-number `kind` fix (#170).

## Tests

Regression tests for each: `load_full` returns host paths; custom typed values use the JSON-RPC shape; custom directives survive the clamp round-trip. ruff + mypy clean; component unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)