### PR TITLE
feat(component): route queries through query-entries; wire get_engine

### DIFF
--- a/src/rustfava/core/filters.py
+++ b/src/rustfava/core/filters.py
@@ -412,12 +412,12 @@ class TimeFilter(EntryFilter):
         self.date_range = DateRange(begin, end)
 
     def apply(self, entries: Sequence[Directive]) -> Sequence[Directive]:
-        from rustfava.rustledger.engine import RustledgerEngine
+        from rustfava.rustledger.backend import get_engine
         from rustfava.rustledger.types import directives_from_json
         from rustfava.rustledger.types import directives_to_json
 
         # Use native rustledger clamp_entries
-        engine = RustledgerEngine.get_instance()
+        engine = get_engine()
         entries_json = directives_to_json(list(entries))
         result = engine.clamp_entries(
             entries_json,

--- a/src/rustfava/rustledger/__init__.py
+++ b/src/rustfava/rustledger/__init__.py
@@ -6,31 +6,10 @@ replacing beancount for parsing, validation, and querying.
 
 from __future__ import annotations
 
-import os
-from typing import Any
-
+from rustfava.rustledger.backend import get_engine
 from rustfava.rustledger.engine import RustledgerEngine
 from rustfava.rustledger.loader import load_string
 from rustfava.rustledger.loader import load_uncached
-
-
-def get_engine() -> Any:
-    """Return the engine named by ``RUSTFAVA_RUSTLEDGER_BACKEND``.
-
-    ``component`` selects the experimental in-process WASI Preview 2 /
-    Component-Model engine (needs the ``component`` extra: ``wasmtime``);
-    anything else (the default) keeps the JSON-RPC :class:`RustledgerEngine`.
-    The component module — and so ``wasmtime`` — is imported lazily, so the
-    default path keeps no extra dependency.
-    """
-    backend = os.environ.get("RUSTFAVA_RUSTLEDGER_BACKEND", "").lower()
-    if backend == "component":
-        from rustfava.rustledger.component_engine import (  # noqa: PLC0415
-            get_component_engine,
-        )
-
-        return get_component_engine()
-    return RustledgerEngine.get_instance()
 
 
 def is_encrypted_file(path: str) -> bool:
@@ -42,7 +21,7 @@ def is_encrypted_file(path: str) -> bool:
     Returns:
         True if file is encrypted
     """
-    return RustledgerEngine.get_instance().is_encrypted(path)
+    return bool(get_engine().is_encrypted(path))
 
 
 __all__ = [

--- a/src/rustfava/rustledger/backend.py
+++ b/src/rustfava/rustledger/backend.py
@@ -1,0 +1,38 @@
+"""Select the rustledger engine backend.
+
+The legacy JSON-RPC engine is still the **default**; set
+``RUSTFAVA_RUSTLEDGER_BACKEND=component`` to opt into the in-process component
+engine (WASI Preview 2 / Component Model, rustledger #1384) during the
+dual-ship window. Flipping the default is tracked in #173.
+
+This lives in its own module — not the package ``__init__`` — so call sites can
+import :func:`get_engine` at module level without a circular import through the
+package.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from rustfava.rustledger.engine import RustledgerEngine
+
+
+def get_engine() -> Any:
+    """Return the engine selected by ``RUSTFAVA_RUSTLEDGER_BACKEND``.
+
+    ``component`` selects the in-process component engine (needs the optional
+    ``wasmtime`` dependency); anything else keeps the JSON-RPC engine, which
+    stays the default during the dual-ship window. If ``wasmtime`` is missing
+    the component engine can't be imported, so fall back to JSON-RPC.
+    """
+    backend = os.environ.get("RUSTFAVA_RUSTLEDGER_BACKEND", "").lower()
+    if backend != "component":
+        return RustledgerEngine.get_instance()
+    try:
+        from rustfava.rustledger.component_engine import (  # noqa: PLC0415
+            get_component_engine,
+        )
+    except ImportError:
+        return RustledgerEngine.get_instance()
+    return get_component_engine()

--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -669,6 +669,30 @@ class RustledgerComponentEngine:
             raw = func(self._store, wit_entries, begin_date, end_date)
             return _marshal(raw, func.type(self._store).result)
 
+    def query_entries(
+        self,
+        entries_json: list[dict[str, Any]],
+        query_string: str,
+    ) -> dict[str, Any]:
+        """Run a BQL query against already-loaded entries (no source re-parse).
+
+        Marshals the entries into typed component values and calls the
+        builder's ``query-entries`` — the typed alternative to re-rendering a
+        filtered entry set back to beancount source text (which can render
+        invalid text). Same ``columns``/``rows``/``errors`` shape as
+        :meth:`query`.
+        """
+        self._ensure_version()
+        with self._lock:
+            fidx = self._component.get_export_index(
+                "query-entries", self._iface(_BUILDER)
+            )
+            func = self._inst.get_func(self._store, fidx)
+            entries_type = func.type(self._store).params[0][1]
+            wit_entries = _unmarshal(list(entries_json), entries_type)
+            raw = func(self._store, wit_entries, query_string)
+            return _marshal(raw, func.type(self._store).result)
+
     # -- stateful ledger handle (WIT `resource session`, rustfava #173) -----
 
     def open_session(self, source: str) -> ComponentSession:

--- a/src/rustfava/rustledger/engine.py
+++ b/src/rustfava/rustledger/engine.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 SUPPORTED_API_MAJOR = 2
 
 # Rustledger release to download
-RUSTLEDGER_VERSION = "v0.16.3"
+RUSTLEDGER_VERSION = "v0.16.4"
 RUSTLEDGER_WASM_URL = (
     f"https://github.com/rustledger/rustledger/releases/download/"
     f"{RUSTLEDGER_VERSION}/rustledger-ffi-wasi-{RUSTLEDGER_VERSION}.wasm"

--- a/src/rustfava/rustledger/loader.py
+++ b/src/rustfava/rustledger/loader.py
@@ -10,7 +10,7 @@ from rustfava.beans.abc import Balance
 from rustfava.beans.abc import Close
 from rustfava.beans.abc import Document
 from rustfava.beans.abc import Open
-from rustfava.rustledger.engine import RustledgerEngine
+from rustfava.rustledger.backend import get_engine
 from rustfava.rustledger.options import options_from_json
 from rustfava.rustledger.types import cost_number_values
 from rustfava.rustledger.types import directives_from_json
@@ -41,7 +41,9 @@ def _sort_entries(entries: list[Directive]) -> list[Directive]:
     return sorted(entries, key=key)
 
 
-def _compute_display_precision(entries_json: list[dict[str, Any]]) -> dict[str, int]:
+def _compute_display_precision(
+    entries_json: list[dict[str, Any]],
+) -> dict[str, int]:
     """Compute display precision from entries.
 
     This is a workaround until rustledger FFI returns display_precision
@@ -78,14 +80,14 @@ def _compute_display_precision(entries_json: list[dict[str, Any]]) -> dict[str, 
                     value = per_unit if per_unit is not None else total
                     if value is not None:
                         track_amount(
-                            {"number": str(value), "currency": cost.get("currency")}
+                            {
+                                "number": str(value),
+                                "currency": cost.get("currency"),
+                            }
                         )
                 track_amount(posting.get("price"))
 
-        elif entry_type == "balance":
-            track_amount(entry.get("amount"))
-
-        elif entry_type == "price":
+        elif entry_type == "balance" or entry_type == "price":
             track_amount(entry.get("amount"))
 
     # Get most common precision for each currency
@@ -204,7 +206,11 @@ def _run_plugins(
                     else:
                         all_errors.append(
                             BeancountError(
-                                source=getattr(err, "source", {"filename": "<plugin>", "lineno": 0}),
+                                source=getattr(
+                                    err,
+                                    "source",
+                                    {"filename": "<plugin>", "lineno": 0},
+                                ),
                                 message=getattr(err, "message", str(err)),
                                 entry=getattr(err, "entry", None),
                             )
@@ -238,7 +244,7 @@ def load_string(
     Returns:
         Tuple of (entries, errors, options)
     """
-    engine = RustledgerEngine.get_instance()
+    engine = get_engine()
     result = engine.load(value, filename)
 
     entries = list(directives_from_json(result.get("entries", [])))
@@ -282,7 +288,7 @@ def load_uncached(
     del is_encrypted  # Rustledger handles GPG decryption automatically
 
     main_path = Path(beancount_file_path)
-    engine = RustledgerEngine.get_instance()
+    engine = get_engine()
 
     # auto_accounts is a synth plugin the engine runs from the ledger's own
     # ``plugin "..."`` declaration during loading; it must NOT be passed via the
@@ -296,7 +302,9 @@ def load_uncached(
     # Compute display_precision if not provided by FFI (workaround)
     options_json = result.get("options", {})
     if not options_json.get("display_precision"):
-        options_json["display_precision"] = _compute_display_precision(entries_json)
+        options_json["display_precision"] = _compute_display_precision(
+            entries_json
+        )
 
     entries = _sort_entries(list(directives_from_json(entries_json)))
     errors = list(_errors_from_json(result.get("errors", []), str(main_path)))

--- a/src/rustfava/rustledger/query.py
+++ b/src/rustfava/rustledger/query.py
@@ -7,7 +7,8 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from rustfava.beans.str import to_string
-from rustfava.rustledger.engine import RustledgerEngine
+from rustfava.rustledger.backend import get_engine
+from rustfava.rustledger.types import directives_to_json
 from rustfava.rustledger.types import RLAmount
 
 if TYPE_CHECKING:
@@ -64,7 +65,10 @@ class RLCursor:
     def fetchall(self) -> list[tuple[Any, ...]]:
         """Fetch all remaining rows."""
         rows = [
-            tuple(_convert_row_value(v, self._columns[i]) for i, v in enumerate(row))
+            tuple(
+                _convert_row_value(v, self._columns[i])
+                for i, v in enumerate(row)
+            )
             for row in self._rows[self._index :]
         ]
         self._index = len(self._rows)
@@ -84,7 +88,8 @@ class RLCursor:
         """Iterate over rows."""
         for row in self._rows[self._index :]:
             yield tuple(
-                _convert_row_value(v, self._columns[i]) for i, v in enumerate(row)
+                _convert_row_value(v, self._columns[i])
+                for i, v in enumerate(row)
             )
 
 
@@ -198,7 +203,7 @@ class RLConnection:
         """Initialize connection."""
         self._entries = entries
         self._options = options
-        self._engine = RustledgerEngine.get_instance()
+        self._engine = get_engine()
         self._source: str | None = None
 
     def set_source(self, source: str) -> None:
@@ -223,11 +228,18 @@ class RLConnection:
             CompilationError: If the query cannot be compiled
             RuntimeError: If source is not set
         """
-        if self._source is None:
-            # Fall back to re-serializing entries (slower but works)
-            self._source = _entries_to_source(self._entries)
-
-        result = self._engine.query(self._source, query_string)
+        if hasattr(self._engine, "query_entries"):
+            # Component engine: query the directive set directly via the typed
+            # `query-entries`, so there is no re-render of entries to beancount
+            # source (which can produce text the parser rejects).
+            result = self._engine.query_entries(
+                directives_to_json(list(self._entries)), query_string
+            )
+        else:
+            if self._source is None:
+                # JSON-RPC engine queries source text; re-serialize the entries.
+                self._source = _entries_to_source(self._entries)
+            result = self._engine.query(self._source, query_string)
 
         errors = result.get("errors", [])
         if errors:
@@ -253,10 +265,9 @@ def _entries_to_source(entries: Sequence[Directive]) -> str:
     """
     parts: list[str] = []
     for entry in entries:
-        if (
-            type(entry).__name__ == "RLCustom"
-            and getattr(entry, "type", "").startswith("fava")
-        ):
+        if type(entry).__name__ == "RLCustom" and getattr(
+            entry, "type", ""
+        ).startswith("fava"):
             continue
         rendered = to_string(entry)
         if rendered:

--- a/tests/test_rustledger_component_engine.py
+++ b/tests/test_rustledger_component_engine.py
@@ -323,6 +323,22 @@ def test_clamp_preserves_custom_typed_values(
     } in (custom["values"])
 
 
+def test_query_entries_matches_source_query(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """`query_entries` queries an already-loaded directive set directly (the
+    typed alternative to re-rendering entries to source), matching `query`."""
+    entries = engine.load(SRC)["entries"]
+    via_entries = engine.query_entries(entries, "SELECT account, position")
+    via_source = engine.query(SRC, "SELECT account, position")
+    assert via_entries["errors"] == []
+    assert via_entries["rows"]
+    assert len(via_entries["rows"]) == len(via_source["rows"])
+    assert [c["name"] for c in via_entries["columns"]] == [
+        c["name"] for c in via_source["columns"]
+    ]
+
+
 def test_open_session_runs_query_filter_clamp(
     engine: RustledgerComponentEngine,
 ) -> None:


### PR DESCRIPTION
Reroutes the rustfava query path to the component's typed `query-entries` (rustledger v0.16.4, #1423) and wires the engine selector so the component backend is reachable end-to-end. **JSON-RPC stays the default** (`RUSTFAVA_RUSTLEDGER_BACKEND=component` opts in) — no behavior change on the default path; this fixes the component path (part of #173).

## What
- **engine**: `RUSTLEDGER_VERSION` → v0.16.4; `component_engine.query_entries` marshals a directive set in and calls `builder.query-entries`.
- **query_shell**: `RLConnection.execute` queries the directive set directly via `query_entries` when the engine supports it, instead of re-rendering the filtered entries to beancount source (`_entries_to_source`) and re-parsing — the latter produced text the parser rejected (the query crashes). JSON-RPC keeps the source path, so `_entries_to_source` stays until that surface is dropped.
- **routing**: `backend.get_engine` selector (JSON-RPC default); load/query/filter/is_encrypted now go through it so the component backend is actually exercised.

## Why
Fava queries *filtered* entry subsets. A full-ledger session can't serve that; the right primitive is the typed entry-set `query-entries` (symmetric with `clamp`/`filter`), so the subset crosses the WIT contract faithfully with no source re-render. See the #173 discussion.

## Impact
Running the full suite via the component (`RUSTFAVA_RUSTLEDGER_BACKEND=component`) **eliminates the query-crash class**. Remaining failures are snapshot diffs + a few inventory/tree shape issues (tracked in #173 for the next pass). The **default JSON-RPC path is unchanged**.

## Tests / checks
New `query_entries` engine test (matches source `query`); component tests green; mypy clean. The default path is unaffected so the JSON-RPC-backed CI passes.

Note: the routing touches `loader.py`/`query.py`/`filters.py`, which carry **pre-existing** ruff debt (function-level imports, long comment lines). This change adds none (loader/query/filters violation count unchanged vs main).