### PR TITLE
fix(component): options/error defaults + query position-cell shape

### DIFF
--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -141,11 +141,30 @@ def _unwrap_query_value(cell: Any) -> Any:  # noqa: PLR0911
     if kind == "amount":
         return {"number": cell["number"], "currency": cell["currency"]}
     if kind == "inventory":
-        return {"positions": cell["value"]}
+        return {"positions": [_drop_none(p) for p in cell["value"]]}
+    if kind == "position":
+        return _drop_none({k: v for k, v in cell.items() if k != "type"})
     if kind == "json":
         return json.loads(cell["value"])
-    # position / interval / metadata: drop the discriminator, keep the fields.
+    # interval / metadata: drop the discriminator, keep the fields.
     return {k: v for k, v in cell.items() if k != "type"}
+
+
+def _drop_none(obj: Any) -> Any:
+    """Drop ``None``-valued keys and sort keys to match ``value_to_json``.
+
+    ``value_to_json`` omits absent ``cost``/``date``/``label`` (rather than
+    emitting ``None``), and serde serializes maps alphabetically (``BTreeMap``)
+    — so a position cell stringifies as ``{currency, number}``. Mirror both so
+    object cells render identically to the JSON-RPC surface.
+    """
+    if isinstance(obj, dict):
+        return {
+            k: _drop_none(v) for k, v in sorted(obj.items()) if v is not None
+        }
+    if isinstance(obj, list):
+        return [_drop_none(v) for v in obj]
+    return obj
 
 
 def _finalize_query_result(result: dict[str, Any]) -> dict[str, Any]:

--- a/src/rustfava/rustledger/loader.py
+++ b/src/rustfava/rustledger/loader.py
@@ -112,10 +112,11 @@ def _errors_from_json(
         if "source" in err:
             source = err["source"]
             err_filename = source.get("filename", filename)
-            err_lineno = source.get("lineno", 0)
+            err_lineno = source.get("lineno") or 0
         else:
             err_filename = err.get("filename", filename)
-            err_lineno = err.get("line", 0)
+            # `line` is `option<u32>` on the component: present-but-None.
+            err_lineno = err.get("line") or 0
 
         result.append(
             BeancountError(

--- a/src/rustfava/rustledger/options.py
+++ b/src/rustfava/rustledger/options.py
@@ -63,7 +63,7 @@ class RLDisplayFormatter:
         if self._render_commas:
             # Add thousand separators
             parts = formatted.split(".")
-            parts[0] = "{:,}".format(int(parts[0]))
+            parts[0] = f"{int(parts[0]):,}"
             formatted = ".".join(parts)
         return formatted
 
@@ -143,9 +143,10 @@ def options_from_json(data: dict[str, Any]) -> BeancountOptions:
         "name_income": data.get("name_income", "Income"),
         "name_expenses": data.get("name_expenses", "Expenses"),
         # Special accounts
-        "account_current_conversions": data.get(
-            "account_current_conversions", "Equity:Conversions:Current"
-        ),
+        # These are `option<string>` on the component surface: present-but-None
+        # (vs absent), so default on falsy, not just on missing key.
+        "account_current_conversions": data.get("account_current_conversions")
+        or "Equity:Conversions:Current",
         "account_current_earnings": data.get(
             "account_current_earnings", "Equity:Earnings:Current"
         ),
@@ -159,20 +160,21 @@ def options_from_json(data: dict[str, Any]) -> BeancountOptions:
             "account_previous_earnings", "Equity:Earnings:Previous"
         ),
         "account_rounding": data.get("account_rounding"),
-        "account_unrealized_gains": data.get(
-            "account_unrealized_gains", "Income:Unrealized"
-        ),
+        "account_unrealized_gains": data.get("account_unrealized_gains")
+        or "Income:Unrealized",
         # Booking and commodities
         "booking_method": RLBooking(data.get("booking_method", "STRICT")),
         "commodities": set(data.get("commodities", [])),
-        "conversion_currency": data.get("conversion_currency", ""),
+        "conversion_currency": data.get("conversion_currency") or "",
         "dcontext": dcontext,
         "display_precision": display_precision,
         # File handling
         "documents": list(data.get("documents", [])),
         "include": list(data.get("include", [])),
         # Tolerances
-        "infer_tolerance_from_cost": data.get("infer_tolerance_from_cost", False),
+        "infer_tolerance_from_cost": data.get(
+            "infer_tolerance_from_cost", False
+        ),
         "inferred_tolerance_default": inferred_tolerance_default,
         "inferred_tolerance_multiplier": Decimal(
             str(data.get("inferred_tolerance_multiplier", "0.5"))


### PR DESCRIPTION
Three component-path fidelity fixes from the #173 snapshot triage. Full suite via the component: **12 → 5 failures** (overall arc: 114 → 5). Default JSON-RPC path unaffected.

## Fixes
1. **Options defaults** — `account_current_conversions` / `account_unrealized_gains` / `conversion_currency` are `option<string>` on the component, arriving present-but-`None`. `options_from_json` defaulted only on a *missing* key; now defaults on falsy. Fixes `test_tree_cap` (`str + None` crash) and `test_api[options]` (and the two `balance_sheet` reports).
2. **Error `lineno`** — component `line` is `option<u32>` (`None`); JSON-RPC emits `0`. Default on falsy in `_errors_from_json`. Fixes `test_api_errors`.
3. **Query position/inventory cells** — drop `None`-valued fields and **sort keys** to match `value_to_json` (serde serializes maps alphabetically), so cells stringify identically to the JSON-RPC surface. Fixes the `journal`/`misc` query-result snapshots.

## Remaining 5 (tracked in #173)
- 3 directive-serialization key-order snapshots (`download_journal`, `payee_transaction`, `trial_balance`) — need deterministic API JSON key ordering; clean but wants validation against the JSON-RPC path.
- 2 metadata-fidelity (`fava_options`, `advanced_filter[overage]`) — the known numeric-metadata-as-text gap (rustledger-side).

ruff + mypy clean on the new code; component unit tests green. (The PR touches loader/options which carry pre-existing ruff debt; this change adds none.)