### PR TITLE
feat(component): consume v0.16.5 — clamp provenance, load filename, narration

### DIFF
--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -616,14 +616,14 @@ class RustledgerComponentEngine:
         """Return the component's ``api_version`` string (e.g. ``"2.1"``)."""
         return self._call(_LEDGER, "version", [])
 
-    def load(self, source: str, filename: str = "<stdin>") -> dict[str, Any]:  # noqa: ARG002
+    def load(self, source: str, filename: str = "<stdin>") -> dict[str, Any]:
         """Parse + book ``source``; returns entries/errors/options/....
 
-        ``filename`` is accepted for API parity with the JSON-RPC engine; the
-        WIT ``load(source)`` has no filename param, so it is unused here.
+        ``filename`` is recorded as the directives' source location (the WIT
+        ``load`` takes it, matching the JSON-RPC engine).
         """
         self._ensure_version()
-        return self._call(_LEDGER, "load", [source])
+        return self._call(_LEDGER, "load", [source, filename])
 
     def query(self, source: str, query_string: str) -> dict[str, Any]:
         """Run a BQL query over ``source``; returns columns/rows/errors."""

--- a/src/rustfava/rustledger/engine.py
+++ b/src/rustfava/rustledger/engine.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 SUPPORTED_API_MAJOR = 2
 
 # Rustledger release to download
-RUSTLEDGER_VERSION = "v0.16.4"
+RUSTLEDGER_VERSION = "v0.16.5"
 RUSTLEDGER_WASM_URL = (
     f"https://github.com/rustledger/rustledger/releases/download/"
     f"{RUSTLEDGER_VERSION}/rustledger-ffi-wasi-{RUSTLEDGER_VERSION}.wasm"

--- a/src/rustfava/rustledger/types.py
+++ b/src/rustfava/rustledger/types.py
@@ -7,7 +7,6 @@ can be constructed from rustledger's JSON output.
 from __future__ import annotations
 
 import datetime
-from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import fields
 from decimal import Decimal
@@ -279,7 +278,7 @@ class RLTransaction(AsDictMixin):
             date=txn_date,
             flag=data.get("flag", "*"),
             payee=data.get("payee"),
-            narration=data.get("narration", ""),
+            narration=data.get("narration") or "",
             tags=frozenset(data.get("tags", [])),
             links=frozenset(data.get("links", [])),
             postings=tuple(
@@ -681,7 +680,7 @@ def directive_from_json(data: dict[str, Any]) -> abc.Directive:
         msg = f"Unknown directive type: {directive_type}"
         raise ValueError(msg)
     # All types in DIRECTIVE_TYPES have from_json class method
-    from_json = getattr(cls, "from_json")
+    from_json = getattr(cls, "from_json")  # noqa: B009  # keep getattr: base abc.Directive lacks the attr (mypy)
     result: abc.Directive = from_json(data)
     return result
 


### PR DESCRIPTION
Companions to rustledger #1425 / **v0.16.5**, closing the last of #173's snapshot triage. **The full rustfava suite now passes via the component backend: 497 passed, 0 failed (was 114).**

## Changes
- **`RUSTLEDGER_VERSION` → v0.16.5** — the component now preserves clamp provenance + the WIT `load` takes a filename (#1425).
- **`component_engine.load`** passes `filename` through to the WIT `load` (was dropped) → source-location metadata matches JSON-RPC. Fixes `fava_options` (`InsertEntryOption.filename`).
- **`types`: narration default** — the component emits absent narration as `null` (present-but-None) where JSON-RPC omits it; `.get(k, "")` returned the None. Fixes `payee_transaction`.

(Clamp provenance fixed `download_journal` + `trial_balance`; posting-meta `advanced_filter` landed in #180.)

## Validation
`RUSTFAVA_RUSTLEDGER_BACKEND=component pytest` → **497 passed, 0 failed**. mypy clean; no new ruff violations (reduced types.py debt by 2). Default JSON-RPC path unchanged.

> CI depends on the v0.16.5 wasm artifact; will go green once the release publishes.

Next: flip the default to the component (#173) — now a one-line `backend.py` change.