### PR TITLE
feat(rustledger): make the component engine the default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ dependencies = [
     "ply>=3.11",
     "pydantic>=2.0",
     "watchfiles>=0.20.0",
+    # Drives the rustledger WASI Preview 2 / Component-Model component
+    # (rustledger #1384), the default engine. Core dep, not an extra, since the
+    # component backend is the default (RUSTFAVA_RUSTLEDGER_BACKEND=jsonrpc opts
+    # back to the legacy JSON-RPC engine).
+    "wasmtime>=45,<46",
 ]
 
 [project.urls]
@@ -63,12 +68,6 @@ excel =[
 # Beancount compatibility - for legacy beancount plugin support and ingest hooks
 beancount-compat = [
     "beancount>=2,<4",
-]
-# Experimental in-process engine driving the rustledger WASI Preview 2 /
-# Component-Model component (rustledger #1384), selected via
-# RUSTFAVA_RUSTLEDGER_BACKEND=component. Default remains the JSON-RPC engine.
-component = [
-    "wasmtime>=45,<46",
 ]
 
 [dependency-groups]

--- a/src/rustfava/rustledger/backend.py
+++ b/src/rustfava/rustledger/backend.py
@@ -1,9 +1,8 @@
 """Select the rustledger engine backend.
 
-The legacy JSON-RPC engine is still the **default**; set
-``RUSTFAVA_RUSTLEDGER_BACKEND=component`` to opt into the in-process component
-engine (WASI Preview 2 / Component Model, rustledger #1384) during the
-dual-ship window. Flipping the default is tracked in #173.
+The in-process component engine (WASI Preview 2 / Component Model, rustledger
+#1384) is the **default**; set ``RUSTFAVA_RUSTLEDGER_BACKEND=jsonrpc`` to opt
+back into the legacy JSON-RPC engine. The flip is tracked in #173.
 
 This lives in its own module — not the package ``__init__`` — so call sites can
 import :func:`get_engine` at module level without a circular import through the
@@ -17,17 +16,19 @@ from typing import Any
 
 from rustfava.rustledger.engine import RustledgerEngine
 
+# Values of ``RUSTFAVA_RUSTLEDGER_BACKEND`` that select the legacy engine.
+_JSONRPC_ALIASES = frozenset({"jsonrpc", "json-rpc", "json"})
+
 
 def get_engine() -> Any:
     """Return the engine selected by ``RUSTFAVA_RUSTLEDGER_BACKEND``.
 
-    ``component`` selects the in-process component engine (needs the optional
-    ``wasmtime`` dependency); anything else keeps the JSON-RPC engine, which
-    stays the default during the dual-ship window. If ``wasmtime`` is missing
-    the component engine can't be imported, so fall back to JSON-RPC.
+    The component engine is the default; ``jsonrpc`` (or ``json-rpc``/``json``)
+    selects the legacy JSON-RPC engine. If ``wasmtime`` can't be imported the
+    component engine is unavailable, so fall back to JSON-RPC rather than crash.
     """
     backend = os.environ.get("RUSTFAVA_RUSTLEDGER_BACKEND", "").lower()
-    if backend != "component":
+    if backend in _JSONRPC_ALIASES:
         return RustledgerEngine.get_instance()
     try:
         from rustfava.rustledger.component_engine import (  # noqa: PLC0415

--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -6,9 +6,9 @@ spawns the ``wasmtime`` CLI with JSON-RPC over stdin/stdout). This driver loads
 ``wasmtime-py``'s component API and calls its **typed** exports directly — no
 subprocess per call, no hand-mirrored JSON DTOs.
 
-It is wired in behind a flag (see ``rustfava.rustledger.get_engine``); the
-JSON-RPC engine stays the default until the component ships as a release
-artifact (``publish = false`` upstream — rustledger ADR-0006 Phase 3).
+This is the **default** engine (see ``rustfava.rustledger.get_engine``);
+``RUSTFAVA_RUSTLEDGER_BACKEND=jsonrpc`` opts back into the legacy JSON-RPC
+engine.
 
 Results are marshalled from the component's typed `Record`/`Variant`/`list`
 values into plain Python by a generic, *type-driven* converter

--- a/src/rustfava/rustledger/options.py
+++ b/src/rustfava/rustledger/options.py
@@ -134,7 +134,9 @@ def options_from_json(data: dict[str, Any]) -> BeancountOptions:
     }
 
     options: BeancountOptions = {
-        "title": data.get("title", ""),
+        # `option<string>` on the component: present-but-None, so default on
+        # falsy (a None title is not a valid str — typeguard catches it).
+        "title": data.get("title") or "",
         "filename": data.get("filename", ""),
         # Root account names
         "name_assets": data.get("name_assets", "Assets"),

--- a/uv.lock
+++ b/uv.lock
@@ -1406,6 +1406,7 @@ dependencies = [
     { name = "markdown2" },
     { name = "ply" },
     { name = "pydantic" },
+    { name = "wasmtime" },
     { name = "watchfiles" },
     { name = "werkzeug" },
 ]
@@ -1413,9 +1414,6 @@ dependencies = [
 [package.optional-dependencies]
 beancount-compat = [
     { name = "beancount" },
-]
-component = [
-    { name = "wasmtime" },
 ]
 excel = [
     { name = "pyexcel" },
@@ -1481,11 +1479,11 @@ requires-dist = [
     { name = "pyexcel", marker = "extra == 'excel'", specifier = ">=0.5" },
     { name = "pyexcel-ods3", marker = "extra == 'excel'", specifier = ">=0.5" },
     { name = "pyexcel-xlsx", marker = "extra == 'excel'", specifier = ">=0.5" },
-    { name = "wasmtime", marker = "extra == 'component'", specifier = ">=45,<46" },
+    { name = "wasmtime", specifier = ">=45,<46" },
     { name = "watchfiles", specifier = ">=0.20.0" },
     { name = "werkzeug", specifier = ">=2.2,<4" },
 ]
-provides-extras = ["excel", "beancount-compat", "component"]
+provides-extras = ["excel", "beancount-compat"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
**Closes #173.** Flips the default rustledger backend from the legacy JSON-RPC engine to the in-process WASI Preview 2 / Component-Model component (rustledger #1384).

## Changes
- **`backend.py`**: default → component; `RUSTFAVA_RUSTLEDGER_BACKEND=jsonrpc` (or `json-rpc`/`json`) opts back into the JSON-RPC engine. The `ImportError`→JSON-RPC fallback stays, so a missing/broken `wasmtime` degrades gracefully.
- **`pyproject.toml`**: `wasmtime` moves from the optional `component` extra to a **core dependency** — the component is the default, so it ships for every install. `uv.lock` regenerated (via uv 0.11).
- Docstrings updated.

## Validation
- Full suite via the component (the new default), on the **released v0.16.5 wasm**: **497 passed, 0 failed** — completing the arc from **114 → 0**.
- This PR's CI runs `test-py` via the component by default (wasmtime is now a core dep installed by the `test` group), so the component path is validated end-to-end in CI.
- `jsonrpc` opt-out routing verified; mypy + ruff clean on changed files.

## Notes
- Windows CI remains disabled (pre-existing wasmtime WASI path limitation, unchanged by this PR); the `jsonrpc` opt-out remains available there.
- The arc: #170/#171/#175/#176/#178/#180/#181 (rustfava) + #1421/#1423/#1425 (rustledger) + releases v0.16.3/v0.16.4/v0.16.5.