### PR TITLE
docs: document the component default backend + wasmtime requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ Download the latest release for your platform from the [Releases page](https://g
 | **Windows** | `.exe` installer or `.msi` |
 | **Linux** | `.AppImage`, `.deb`, `.rpm`, or `.tar.gz` |
 
-> **Note for Linux deb/rpm users**: The server component requires [wasmtime](https://wasmtime.dev/). Install it with:
+> **Backends**: rustfava runs the rustledger engine as an in-process WebAssembly
+> component, so the `wasmtime` Python package ships as a dependency and the
+> default backend works out of the box — no separate install needed.
+>
+> To opt back into the legacy JSON-RPC engine
+> (`RUSTFAVA_RUSTLEDGER_BACKEND=jsonrpc`), you must install the
+> [wasmtime](https://wasmtime.dev/) **CLI** separately (it is *not* a Python
+> dependency); the component backend does not need it:
 > ```bash
 > curl https://wasmtime.dev/install.sh -sSf | bash
 > ```
@@ -50,7 +57,7 @@ Download the latest release for your platform from the [Releases page](https://g
 | Method | Command |
 |--------|---------|
 | **Docker** | `docker run -p 5000:5000 -v /path/to/ledger:/data ghcr.io/rustledger/rustfava /data/main.beancount` |
-| **PyPI** | `uv tool install rustfava` (requires Python 3.13+ and [wasmtime](https://wasmtime.dev/)) |
+| **PyPI** | `uv tool install rustfava` (requires Python 3.13+; the `wasmtime` runtime is installed automatically) |
 | **Nix** | `nix run github:rustledger/rustfava#desktop` |
 
 <sub>Missing your platform? [Open an issue](https://github.com/rustledger/rustfava/issues/new) to request it.</sub>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,27 @@
 
 There are several ways to deploy rustfava depending on your needs.
 
+## Backends
+
+rustfava runs the rustledger engine in one of two ways, selected by the
+`RUSTFAVA_RUSTLEDGER_BACKEND` environment variable:
+
+- **`component`** (default) — runs the rustledger WebAssembly component
+  in-process via the `wasmtime` Python package, which is installed
+  automatically as a dependency. Nothing extra to set up.
+- **`jsonrpc`** (`json-rpc`/`json`) — the legacy engine, which shells out to the
+  `wasmtime` **CLI** over JSON-RPC. The CLI is **not** a Python dependency, so
+  you must install it separately for this backend:
+
+  ```bash
+  curl https://wasmtime.dev/install.sh -sSf | bash
+  ```
+
+If `RUSTFAVA_RUSTLEDGER_BACKEND` is unset (or set to anything other than a
+JSON-RPC alias) the component backend is used. As a safety net, if the
+`wasmtime` package can't be imported, rustfava falls back to the JSON-RPC engine
+— which then requires the CLI above.
+
 ## Desktop App
 
 For personal use, the [desktop app](https://github.com/rustledger/rustfava/releases) is the simplest option. It runs entirely locally with no server setup required.


### PR DESCRIPTION
Follow-up to the backend flip (#183): the docs still listed the `wasmtime` **CLI** as an unconditional requirement, but post-flip the default backend runs the component via the `wasmtime` **Python package** (a dependency, installed automatically) and needs no separate install.

## Changes
- **README**: reframe the wasmtime note — the CLI is only needed for the legacy `RUSTFAVA_RUSTLEDGER_BACKEND=jsonrpc` backend (and the `ImportError` fallback); the default works out of the box. PyPI row no longer lists wasmtime as a manual prerequisite.
- **docs/deployment.md**: new "Backends" section documenting the env var, the default (`component`), the opt-out (`jsonrpc`), and that the fallback requires the wasmtime CLI.

Captures the rough edge noted while reviewing the wasmtime dependency story: a fresh `pip install` gets wasmtime-py (component works) but not the CLI, so the `jsonrpc` opt-out needs the CLI installed separately.