### PR TITLE
ci: enable Windows tests (component runs fine; fix uppercase-hex address normalization)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,11 @@ jobs:
           # Use Python 3.13 for macOS as beancount lacks 3.14 wheels
           - os: "macos-latest"
             py: "3.13"
-          # Windows tests disabled: wasmtime WASI has issues with Windows paths
-          # See: https://github.com/bytecodealliance/wasmtime/issues/XXX
-          # - os: "windows-latest"
-          #   py: "3.13"
+          # The component engine runs correctly on Windows; the only snag was
+          # uppercase hex in object-address snapshot normalization (fixed in
+          # conftest). beancount lacks 3.14 wheels, so pin 3.13.
+          - os: "windows-latest"
+            py: "3.13"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,8 +202,9 @@ def snapshot(
         out = re.sub(r'id="ledger-mtime">\d+', 'id="ledger-mtime">MTIME', out)
         # replace env-dependant info
         out = re.sub(r'have_excel":\s*(false|False)', 'have_excel": true', out)
-        # replace object addresses
-        out = re.sub(r' object at 0x[0-9a-f]+>', ' object at ADDR>', out)
+        # replace object addresses (hex is uppercase on Windows, lowercase on
+        # POSIX — match both so snapshots are platform-independent)
+        out = re.sub(r' object at 0x[0-9a-fA-F]+>', ' object at ADDR>', out)
         # normalize non-deterministic set/dict repr in beancount_options
         out = re.sub(
             r'"commodities":"[^"]+"',


### PR DESCRIPTION
The component engine runs correctly on Windows — re-enabling the `windows-latest` test job (disabled since January over presumed wasmtime WASI path issues that **do not** occur with the component backend).

## Root cause of the lone failure
`test_api[options]` failed only because CPython formats object addresses with **uppercase** hex on Windows (`...RLDisplayContext object at 0x...B82BD0`), while the conftest normalizer matched lowercase only (`r' object at 0x[0-9a-f]+>'`) — so `dcontext`'s repr address wasn't replaced with `ADDR`. Every other field (including `filename`/`include` paths) matched identically.

## Fix
- conftest: widen the address regex to `[0-9a-fA-F]+` (platform-independent).
- test.yml: re-enable the `windows-latest` (py 3.13) matrix entry.

Verified: full `test-py` matrix incl. windows-latest is green on this branch.