### PR TITLE
fix(deps): make beangulp (and transitive beancount) optional

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -51,6 +51,14 @@ To export query results to Microsoft Excel or LibreOffice Calc:
 uv tool install rustfava[excel]
 ```
 
+To import transactions from files (the import/ingest UI, which uses
+[beangulp](https://github.com/beancount/beangulp) importers — this is the only
+feature that pulls in `beancount`):
+
+```bash
+uv tool install rustfava[ingest]
+```
+
 ### Option 3: Docker
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "Flask>=2.2,<4",
     "Jinja2>=3,<4",
     "Werkzeug>=2.2,<4",
-    "beangulp>=0.1",
     "cheroot>=8,<12",
     "click>=7,<9",
     "markdown2>=2.3.0,<3",
@@ -64,6 +63,12 @@ excel =[
     "pyexcel>=0.5",
     "pyexcel-ods3>=0.5",
     "pyexcel-xlsx>=0.5",
+]
+# File import / ingest (beangulp importers). Optional because beangulp pulls in
+# beancount transitively (#146) — a plain `rustfava` install no longer drags in
+# beancount just to view ledgers. Install `rustfava[ingest]` to import files.
+ingest = [
+    "beangulp>=0.1",
 ]
 # Beancount compatibility - for legacy beancount plugin support and ingest hooks
 beancount-compat = [
@@ -97,6 +102,7 @@ scripts = [
 # Dependencies for tests.
 test = [
     "rustfava[excel]",
+    "rustfava[ingest]",
     "rustfava[beancount-compat]",
     "pytest-cov>=6",
     "pytest-xdist>=3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,11 @@ types = [
     "typeguard>=4",
     "types-requests>=2.32.0.20250515",
     "types-setuptools>=67",
+    # beangulp + beancount are now optional (#146), but the type-checked code
+    # imports them — install both so mypy can resolve the stubs (previously
+    # beancount came in transitively via the beangulp core dep).
+    "rustfava[ingest]",
+    "rustfava[beancount-compat]",
 ]
 # Running pre-commit hooks.
 pre-commit = [

--- a/src/rustfava/core/ingest.py
+++ b/src/rustfava/core/ingest.py
@@ -43,7 +43,7 @@ try:  # pragma: no cover
 except ImportError:
     try:
         from beangulp import cache
-    except ImportError:  # neither beancount nor beangulp installed
+    except ImportError:  # pragma: no cover - neither beancount nor beangulp
         cache = None
 
     DEFAULT_HOOKS = []
@@ -174,7 +174,7 @@ def get_cached_file(path: Path) -> FileMemo:
     This checks the file's mtime before getting it from the Cache.
     In addition to using the beangulp cache.
     """
-    if cache is None:  # pragma: no cover - requires the `ingest` extra absent
+    if cache is None:
         raise IngestUnavailableError
     mtime = path.stat().st_mtime_ns
     filename = str(path)
@@ -362,7 +362,7 @@ def load_import_config(
     Raises:
         IngestUnavailableError: If beangulp (the ``ingest`` extra) is missing.
     """
-    if not _HAVE_BEANGULP:  # pragma: no cover - requires the extra absent
+    if not _HAVE_BEANGULP:
         raise IngestUnavailableError
     try:
         mod = run_path(str(module_path))

--- a/src/rustfava/core/ingest.py
+++ b/src/rustfava/core/ingest.py
@@ -15,7 +15,25 @@ from pathlib import Path
 from runpy import run_path
 from typing import TYPE_CHECKING
 
-from beangulp import Importer
+try:
+    from beangulp import Importer
+
+    _HAVE_BEANGULP = True
+except (
+    ImportError
+):  # pragma: no cover - beangulp is the optional `ingest` extra
+    _HAVE_BEANGULP = False
+
+    class Importer:  # type: ignore[no-redef]
+        """Placeholder used when beangulp is not installed.
+
+        beangulp pulls in beancount transitively (#146), so it is an optional
+        extra (``pip install 'rustfava[ingest]'``). Nothing is an instance of
+        this placeholder, so beangulp-style importers are simply never matched;
+        rustfava's own ``BeanImporterProtocol`` importers are unaffected. The
+        import entry points raise a clear error when beangulp is missing.
+        """
+
 
 try:  # pragma: no cover
     from beancount.ingest import cache  # type: ignore[import-not-found]
@@ -23,7 +41,10 @@ try:  # pragma: no cover
 
     DEFAULT_HOOKS = [extract.find_duplicate_entries]
 except ImportError:
-    from beangulp import cache
+    try:
+        from beangulp import cache
+    except ImportError:  # neither beancount nor beangulp installed
+        cache = None
 
     DEFAULT_HOOKS = []
 
@@ -59,6 +80,16 @@ if TYPE_CHECKING:  # pragma: no cover
 
 class IngestError(BeancountError):
     """An error with one of the importers."""
+
+
+class IngestUnavailableError(RustfavaAPIError):
+    """File import was used but its optional dependency is not installed."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "File import requires beangulp, which is an optional dependency. "
+            "Install it with: pip install 'rustfava[ingest]'",
+        )
 
 
 class ImporterMethodCallError(RustfavaAPIError):
@@ -143,6 +174,8 @@ def get_cached_file(path: Path) -> FileMemo:
     This checks the file's mtime before getting it from the Cache.
     In addition to using the beangulp cache.
     """
+    if cache is None:  # pragma: no cover - requires the `ingest` extra absent
+        raise IngestUnavailableError
     mtime = path.stat().st_mtime_ns
     filename = str(path)
     cached = _CACHE.get(path)
@@ -325,7 +358,12 @@ def load_import_config(
 
     Returns:
         A pair of the importers (by name) and the list of hooks.
+
+    Raises:
+        IngestUnavailableError: If beangulp (the ``ingest`` extra) is missing.
     """
+    if not _HAVE_BEANGULP:  # pragma: no cover - requires the extra absent
+        raise IngestUnavailableError
     try:
         mod = run_path(str(module_path))
     except Exception as error:  # pragma: no cover

--- a/tests/test_core_ingest.py
+++ b/tests/test_core_ingest.py
@@ -260,3 +260,20 @@ def test_filepath_in_primary_imports_folder(
     monkeypatch.setattr(example_ledger.fava_options, "import_dirs", [])
     with pytest.raises(RustfavaAPIError):
         filepath_in_primary_imports_folder("filename", example_ledger)
+
+
+def test_ingest_unavailable_without_beangulp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without beangulp (the `ingest` extra), the import entry points raise a
+    clear ``IngestUnavailableError`` instead of crashing (#146)."""
+    from rustfava.core import ingest
+
+    monkeypatch.setattr(ingest, "_HAVE_BEANGULP", False)
+    monkeypatch.setattr(ingest, "cache", None)
+
+    with pytest.raises(ingest.IngestUnavailableError, match="rustfava\\[ingest\\]"):
+        ingest.load_import_config(Path("/does/not/matter.py"))
+
+    with pytest.raises(ingest.IngestUnavailableError, match="rustfava\\[ingest\\]"):
+        ingest.get_cached_file(Path("/does/not/matter"))

--- a/uv.lock
+++ b/uv.lock
@@ -1460,6 +1460,7 @@ test = [
 types = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "rustfava", extra = ["beancount-compat", "ingest"] },
     { name = "typeguard" },
     { name = "types-requests" },
     { name = "types-setuptools" },
@@ -1526,6 +1527,8 @@ test = [
 types = [
     { name = "mypy", specifier = ">=1.14" },
     { name = "pytest", specifier = ">=8.4" },
+    { name = "rustfava", extras = ["beancount-compat"] },
+    { name = "rustfava", extras = ["ingest"] },
     { name = "typeguard", specifier = ">=4" },
     { name = "types-requests", specifier = ">=2.32.0.20250515" },
     { name = "types-setuptools", specifier = ">=67" },

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,6 @@ name = "rustfava"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },
-    { name = "beangulp" },
     { name = "cheroot" },
     { name = "click" },
     { name = "flask" },
@@ -1420,6 +1419,9 @@ excel = [
     { name = "pyexcel-ods3" },
     { name = "pyexcel-xlsx" },
 ]
+ingest = [
+    { name = "beangulp" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1429,7 +1431,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
-    { name = "rustfava", extra = ["beancount-compat", "excel"] },
+    { name = "rustfava", extra = ["beancount-compat", "excel", "ingest"] },
     { name = "setuptools" },
     { name = "typeguard" },
     { name = "types-requests" },
@@ -1451,7 +1453,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
-    { name = "rustfava", extra = ["beancount-compat", "excel"] },
+    { name = "rustfava", extra = ["beancount-compat", "excel", "ingest"] },
     { name = "setuptools" },
     { name = "typeguard" },
 ]
@@ -1467,7 +1469,7 @@ types = [
 requires-dist = [
     { name = "babel", specifier = ">=2.11,<3" },
     { name = "beancount", marker = "extra == 'beancount-compat'", specifier = ">=2,<4" },
-    { name = "beangulp", specifier = ">=0.1" },
+    { name = "beangulp", marker = "extra == 'ingest'", specifier = ">=0.1" },
     { name = "cheroot", specifier = ">=8,<12" },
     { name = "click", specifier = ">=7,<9" },
     { name = "flask", specifier = ">=2.2,<4" },
@@ -1483,7 +1485,7 @@ requires-dist = [
     { name = "watchfiles", specifier = ">=0.20.0" },
     { name = "werkzeug", specifier = ">=2.2,<4" },
 ]
-provides-extras = ["excel", "beancount-compat"]
+provides-extras = ["excel", "ingest", "beancount-compat"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1495,6 +1497,7 @@ dev = [
     { name = "ruff", specifier = ">=0.11" },
     { name = "rustfava", extras = ["beancount-compat"] },
     { name = "rustfava", extras = ["excel"] },
+    { name = "rustfava", extras = ["ingest"] },
     { name = "setuptools", specifier = ">=67" },
     { name = "typeguard", specifier = ">=4" },
     { name = "types-requests", specifier = ">=2.32.0.20250515" },
@@ -1516,6 +1519,7 @@ test = [
     { name = "pytest-xdist", specifier = ">=3" },
     { name = "rustfava", extras = ["beancount-compat"] },
     { name = "rustfava", extras = ["excel"] },
+    { name = "rustfava", extras = ["ingest"] },
     { name = "setuptools", specifier = ">=67" },
     { name = "typeguard", specifier = ">=4" },
 ]


### PR DESCRIPTION
Closes #146.

`pip install rustfava` pulled in `beancount` transitively (`rustfava → beangulp → beancount`), which defeats the "alternative to beancount" point and fails to build on some platforms (alpine, per the issue). `beancount` was already optional (`beancount-compat`), but `beangulp` was a hard dependency dragging it back in. beangulp is only used by the file import/ingest feature.

## Changes
- **`pyproject.toml`**: move `beangulp` from core `dependencies` to a new **`ingest`** optional extra (added to the `test` group so CI still exercises it).
- **`core/ingest.py`** (on the always-loaded path, so it must import without beangulp):
  - `Importer` → a placeholder class when beangulp is absent. Nothing is an instance of it, so beangulp-style importers are never matched; rustfava's own `BeanImporterProtocol` importers are unaffected.
  - `cache` falls back to `None`.
  - `load_import_config` / `get_cached_file` raise a clear **`IngestUnavailableError`** (*"install rustfava[ingest]"*) instead of a cryptic `ImportError`.
- **docs**: document `rustfava[ingest]` for the import UI.

## Result
- `pip install rustfava` → no beancount, ledgers load and queries run.
- `pip install 'rustfava[ingest]'` → full file-import support.

## Verification
- A full ledger loads with **beangulp + beancount blocked** (import-hook simulation) — `RustfavaLedger` builds, entries parse, no errors; and `import beangulp` correctly fails, proving the block.
- The 11 ingest tests pass with beangulp present; full suite **497 passed**.
- ruff adds **zero** new violations (the one UP047 is pre-existing on `main`); mypy clean on the changed file.