### PR TITLE
fix(engine): actionable errors when the legacy backend can't start

### DIFF
--- a/src/rustfava/rustledger/backend.py
+++ b/src/rustfava/rustledger/backend.py
@@ -12,9 +12,11 @@ package.
 from __future__ import annotations
 
 import os
+import shutil
 from typing import Any
 
 from rustfava.rustledger.engine import RustledgerEngine
+from rustfava.rustledger.engine import RustledgerError
 
 # Values of ``RUSTFAVA_RUSTLEDGER_BACKEND`` that select the legacy engine.
 _JSONRPC_ALIASES = frozenset({"jsonrpc", "json-rpc", "json"})
@@ -23,9 +25,8 @@ _JSONRPC_ALIASES = frozenset({"jsonrpc", "json-rpc", "json"})
 def get_engine() -> Any:
     """Return the engine selected by ``RUSTFAVA_RUSTLEDGER_BACKEND``.
 
-    The component engine is the default; ``jsonrpc`` (or ``json-rpc``/``json``)
-    selects the legacy JSON-RPC engine. If ``wasmtime`` can't be imported the
-    component engine is unavailable, so fall back to JSON-RPC rather than crash.
+    The in-process component engine is the default; ``jsonrpc`` (or
+    ``json-rpc``/``json``) selects the legacy JSON-RPC engine.
     """
     backend = os.environ.get("RUSTFAVA_RUSTLEDGER_BACKEND", "").lower()
     if backend in _JSONRPC_ALIASES:
@@ -34,6 +35,20 @@ def get_engine() -> Any:
         from rustfava.rustledger.component_engine import (  # noqa: PLC0415
             get_component_engine,
         )
-    except ImportError:
-        return RustledgerEngine.get_instance()
+    except ImportError as exc:
+        # The default component backend needs the `wasmtime` Python package.
+        # The legacy JSON-RPC engine instead needs an external `wasmtime` CLI
+        # binary that most users don't have — silently falling back to it just
+        # turns "component unavailable" into a cryptic "wasmtime not found" /
+        # "Empty response" later (rustfava #136/#120). Only fall back if the
+        # CLI is actually present; otherwise fail with an actionable message.
+        if shutil.which("wasmtime"):
+            return RustledgerEngine.get_instance()
+        msg = (
+            "The rustledger component backend is unavailable: the `wasmtime` "
+            "package could not be imported. Reinstall rustfava (wasmtime is a "
+            "required dependency), or install the wasmtime CLI and set "
+            "RUSTFAVA_RUSTLEDGER_BACKEND=jsonrpc."
+        )
+        raise RustledgerError(msg) from exc
     return get_component_engine()

--- a/src/rustfava/rustledger/engine.py
+++ b/src/rustfava/rustledger/engine.py
@@ -108,7 +108,12 @@ class RustledgerEngine:
         # Find wasmtime binary
         self._wasmtime = shutil.which("wasmtime")
         if self._wasmtime is None:
-            msg = "wasmtime not found in PATH. Install with: cargo install wasmtime-cli"
+            msg = (
+                "wasmtime CLI not found in PATH. The legacy JSON-RPC backend "
+                "needs the `wasmtime` binary (cargo install wasmtime-cli). "
+                "The default in-process component backend needs no external "
+                "binary — unset RUSTFAVA_RUSTLEDGER_BACKEND to use it."
+            )
             raise RuntimeError(msg)
 
     @staticmethod
@@ -197,7 +202,13 @@ class RustledgerEngine:
         # JSON-RPC always returns valid JSON on stdout (even for errors)
         if not result.stdout.strip():
             error_msg = result.stderr.strip() or f"Exit code {result.returncode}"
-            raise RustledgerError(f"Empty response: {error_msg}")
+            raise RustledgerError(
+                f"The rustledger WASI subprocess produced no output ({error_msg}). "
+                "This legacy JSON-RPC backend launches a `wasmtime` binary, which "
+                "macOS Gatekeeper can block. The default in-process component "
+                "backend needs no subprocess — upgrade rustfava, or unset "
+                "RUSTFAVA_RUSTLEDGER_BACKEND, to use it. (rustfava #136/#120)",
+            )
 
         try:
             response = json.loads(result.stdout)


### PR DESCRIPTION
Improves the failure UX behind #136 / #120 (macOS "Server failed to start" / "Empty response: rustledger-ffi-wasi").

## Root cause (for the record)
Those reports are from the **legacy JSON-RPC backend**, which spawns a `wasmtime` CLI **subprocess** — and macOS Gatekeeper blocks the bundled binary (the reporter even had to `xattr -d com.apple.quarantine`). The substantive fix already exists: the **in-process component backend is now the default** (#183, no subprocess). Those reports predate that release, so the real resolution is shipping it — see the issue comments.

## What this PR does (the remaining sharp edges)
Makes the legacy / fallback path fail with guidance instead of cryptically:
- **"Empty response"** now explains the subprocess/Gatekeeper cause and points at the component backend.
- **"wasmtime CLI not found"** explains the default component backend needs no external binary.
- **`get_engine` fallback footgun fixed**: when the component backend is unavailable it no longer *silently* falls back to the JSON-RPC engine (which needs a `wasmtime` CLI binary users don't have — producing exactly those cryptic errors). It falls back only if the CLI is actually present, else raises a clear "reinstall rustfava" error.

Default path unchanged. Verified: component is still selected by default; the blocked-component fallback raises the actionable error; engine + component tests pass (25); mypy clean; zero new lint (engine.py's pre-existing E501 debt is untouched — that crate is slated for removal in rustledger#1419).