### PR TITLE
fix(holdings): order by SELECT alias so the holdings query compiles (#190)

### DIFF
--- a/frontend/src/reports/holdings/index.ts
+++ b/frontend/src/reports/holdings/index.ts
@@ -30,7 +30,7 @@ SELECT
   cost_date as acquisition_date
 WHERE account_sortkey(account) ~ "^[01]"
 GROUP BY account, cost_date, currency, cost_currency, cost_number, account_sortkey(account)
-ORDER BY account_sortkey(account), currency, cost_date
+ORDER BY account_sortkey(account), currency, acquisition_date
 `.trim(),
   by_account: `
 SELECT


### PR DESCRIPTION
## Summary

Fixes #190 — the **Holdings** report returns `HTTP 500: column 'cost_date' not found`.

### Root cause
The "all" holdings BQL query (`frontend/src/reports/holdings/index.ts`) selects `cost_date as acquisition_date`, groups by `cost_date`, but then **orders by the raw `cost_date`**. In the rustledger query engine, an `ORDER BY` expression that matches a SELECT target is treated as already-projected even when that target carries a *different alias*, so no hidden sort column is appended. The aggregated result only exposes the `acquisition_date` output column, so `sort_results` can't find `cost_date` and raises `column 'cost_date' not found` → 500.

`cost_date` is a fully supported column; this is purely an `ORDER BY` alias-resolution interaction.

### Fix
Order by the SELECT alias (`acquisition_date`), which the result actually exposes. Verified against the bundled engine: the full "all" query now returns rows with no error.

### Follow-up
The underlying engine defect (aliased `ORDER BY` target dropping the hidden sort column) is filed upstream in the rustledger repo so other aliased-ORDER-BY queries are covered at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)