### PR TITLE
fix(help): resolve version without raising when metadata is absent (#191)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ npm-debug.log
 /desktop/bun.lockb
 /desktop/.vite/
 
+# setuptools_scm-generated version file
+/src/rustfava/_version.py
+
 # Rustledger build artifacts
 /src/rustfava/rustledger/.wasm-version
 /src/rustfava/rustledger/*.wasm

--- a/contrib/pyinstaller_spec.spec
+++ b/contrib/pyinstaller_spec.spec
@@ -80,6 +80,28 @@ try:
 except Exception:
     pass
 
+# Ensure rustfava can report its version from the frozen binary. The bundle
+# ships no dist-info metadata, so importlib.metadata.version() fails and
+# rustfava falls back to rustfava._version (see issue #191). Generate that
+# module here from RUSTFAVA_VERSION (set from the git tag on release builds)
+# or setuptools_scm when building from a full source checkout.
+version_file = rustfava_dir / "_version.py"
+if not version_file.exists():
+    version = os.environ.get("RUSTFAVA_VERSION")
+    if not version:
+        try:
+            from setuptools_scm import get_version
+
+            version = get_version(root=str(project_root))
+        except Exception:
+            version = None
+    if version:
+        version_file.write_text(
+            f'version = "{version}"\n__version__ = version\n'
+        )
+if version_file.exists():
+    hiddenimports.append("rustfava._version")
+
 a = Analysis(
     [str(rustfava_dir / "cli.py")],
     pathex=[str(src_dir)],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,8 @@ testpaths = ["tests"]
 [tool.coverage.run]
 branch = true
 omit = [
+    # setuptools_scm-generated at build time (issue #191); not source code
+    "src/rustfava/_version.py",
     "src/rustfava/beans/types.py",
     "src/rustfava/ext/auto_commit.py",
     # Rustledger integration - new code with many error handling paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,9 @@ include-package-data = true
 where = ["src"]
 
 [tool.setuptools_scm]
+# Emit the resolved version into the package so builds without dist-info
+# metadata (PyInstaller sidecar, .deb) can still report it (issue #191).
+version_file = "src/rustfava/_version.py"
 
 [tool.black]
 line-length = 79

--- a/src/rustfava/__init__.py
+++ b/src/rustfava/__init__.py
@@ -22,9 +22,30 @@ LOCALES = [
 ]
 
 
-def __getattr__(name: str) -> str:
-    if name == "__version__":
+def _resolve_version() -> str:
+    """Resolve the rustfava version without raising.
+
+    Installed wheels expose the version via ``importlib.metadata``. Packaged
+    builds (PyInstaller sidecar, ``.deb``) ship the source without dist-info
+    metadata, so fall back to the setuptools_scm-generated ``_version.py`` and
+    finally to a sentinel rather than raising ``PackageNotFoundError`` (which
+    previously 500'd the help page, see issue #191).
+    """
+    try:
         from importlib.metadata import version
 
         return version("rustfava")
+    except Exception:  # noqa: BLE001 - any metadata failure falls through
+        pass
+    try:
+        from ._version import version  # type: ignore[import-not-found]
+
+        return version
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def __getattr__(name: str) -> str:
+    if name == "__version__":
+        return _resolve_version()
     raise AttributeError(name)

--- a/src/rustfava/__init__.py
+++ b/src/rustfava/__init__.py
@@ -32,15 +32,15 @@ def _resolve_version() -> str:
     previously 500'd the help page, see issue #191).
     """
     try:
-        from importlib.metadata import version
+        from importlib.metadata import version as metadata_version
 
-        return version("rustfava")
-    except Exception:  # noqa: BLE001 - any metadata failure falls through
+        return metadata_version("rustfava")
+    except Exception:  # noqa: BLE001, S110 - any metadata failure falls through
         pass
     try:
-        from ._version import version  # type: ignore[import-not-found]
+        from ._version import version as scm_version
 
-        return version
+        return str(scm_version)
     except Exception:  # noqa: BLE001
         return "unknown"
 

--- a/src/rustfava/application.py
+++ b/src/rustfava/application.py
@@ -428,9 +428,9 @@ def _setup_routes(fava_app: Flask) -> None:  # noqa: PLR0915
     @fava_app.route("/<bfile>/help/<page_slug>")
     def help_page(page_slug: str) -> str:
         """rustfava's included documentation."""
-        from importlib.metadata import version
-
         from markdown2 import markdown
+
+        from rustfava import __version__ as rustfava_version
 
         # Validate against whitelist (defense-in-depth: also check for path traversal)
         if page_slug not in HELP_PAGES or "/" in page_slug or "\\" in page_slug:
@@ -452,7 +452,7 @@ def _setup_routes(fava_app: Flask) -> None:  # noqa: PLR0915
             help_html=Markup(  # noqa: S704
                 render_template_string(
                     html,
-                    rustfava_version=version("rustfava"),
+                    rustfava_version=rustfava_version,
                 ),
             ),
             HELP_PAGES=HELP_PAGES,

--- a/src/rustfava/cli.py
+++ b/src/rustfava/cli.py
@@ -8,15 +8,9 @@ from pathlib import Path
 
 import click
 
-# Version for PyInstaller builds where importlib.metadata is unavailable
-__version__ = "0.1.11"
-
-try:
-    from importlib.metadata import version as get_version
-
-    __version__ = get_version("rustfava")
-except Exception:  # pragma: no cover
-    pass
+# Resilient version lookup (handles PyInstaller / .deb builds without
+# package metadata); see rustfava._resolve_version.
+from rustfava import __version__
 
 
 class AddressInUse(click.ClickException):  # noqa: D101

--- a/tests/test_version_resolution.py
+++ b/tests/test_version_resolution.py
@@ -1,0 +1,62 @@
+"""Version resolution never raises, whatever the packaging situation.
+
+Regression coverage for https://github.com/rustledger/rustfava/issues/191 —
+packaged builds (PyInstaller sidecar, ``.deb``) ship the source without
+``*.dist-info`` metadata, and the help page 500'd with
+``PackageNotFoundError`` on the unguarded ``importlib.metadata.version``
+call. ``rustfava._resolve_version`` falls back to the setuptools_scm-generated
+``_version.py`` and finally to a sentinel.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import sys
+import types
+
+import pytest
+
+import rustfava
+
+
+@pytest.fixture
+def no_dist_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the ``importlib.metadata`` lookup fail like a packaged build."""
+
+    def raise_not_found(_name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(importlib.metadata, "version", raise_not_found)
+
+
+def test_installed_wheel_reports_metadata_version() -> None:
+    """The normal path: dist-info metadata is present (this test env)."""
+    version = rustfava._resolve_version()
+    assert version
+    assert version != "unknown"
+
+
+@pytest.mark.usefixtures("no_dist_metadata")
+def test_falls_back_to_scm_version_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No metadata, but the setuptools_scm version file is bundled."""
+    fake = types.ModuleType("rustfava._version")
+    fake.version = "1.2.3+packaged"  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "rustfava._version", fake)
+    assert rustfava._resolve_version() == "1.2.3+packaged"
+
+
+@pytest.mark.usefixtures("no_dist_metadata")
+def test_falls_back_to_sentinel_when_nothing_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Neither metadata nor a version file: a sentinel, never an exception."""
+    monkeypatch.setitem(sys.modules, "rustfava._version", None)
+    assert rustfava._resolve_version() == "unknown"
+
+
+def test_module_getattr_serves_version_and_rejects_others() -> None:
+    assert rustfava.__version__ == rustfava._resolve_version()
+    with pytest.raises(AttributeError):
+        _ = rustfava.no_such_attribute


### PR DESCRIPTION
## Summary

Fixes #191 — the **Help** page returns `HTTP 500 (PackageNotFoundError: No package metadata was found for rustfava)` on packaged installs (e.g. the `.deb`).

### Root cause
`help_page` called `importlib.metadata.version("rustfava")` with no fallback. Packaged builds (PyInstaller sidecar, `.deb`) ship the source **without** `*.dist-info` metadata, so the lookup raises `PackageNotFoundError` and the view 500s. The same unguarded lookup existed in `__init__.py`, and `cli.py` carried a stale hard-coded `"0.1.11"` fallback.

### Fix
Centralize one resilient resolver, `rustfava._resolve_version`, surfaced via the package `__version__`:
1. `importlib.metadata.version` (installed wheels)
2. setuptools_scm-generated `_version.py` (built artifacts)
3. `"unknown"` sentinel — never raises

`application.py` and `cli.py` now both consume `rustfava.__version__`, removing the duplicated logic and the stale literal. `setuptools_scm` is configured with `version_file = "src/rustfava/_version.py"` (gitignored) so built artifacts that lack dist-info still report the true version instead of `unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)