### PR TITLE
fix(ci): build x64 macOS sidecar on an Intel runner and verify arch (#193)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -144,8 +144,10 @@ jobs:
             aarch64-*) EXPECT="arm64" ;;
             *) echo "::error::Unknown macOS target ${{ matrix.target }}"; exit 1 ;;
           esac
-          if ! file "$BIN" | grep -q "$EXPECT"; then
-            echo "::error::Sidecar arch mismatch: expected $EXPECT for ${{ matrix.target }}"
+          # Use `file -b` (no filename) so the sidecar_name — which itself
+          # contains "x86_64"/"aarch64" — can't false-match the grep.
+          if ! file -b "$BIN" | grep -qw "$EXPECT"; then
+            echo "::error::Sidecar arch mismatch: expected $EXPECT for ${{ matrix.target }}, got: $(file -b "$BIN")"
             exit 1
           fi
 
@@ -334,18 +336,24 @@ jobs:
           ls -la "$APP_PATH" || { echo "App bundle not found!"; exit 1; }
           file "$BINARY"
 
-          # Verify the bundled sidecar matches the target arch (issue #193)
+          # Verify the bundled sidecar matches the target arch (issue #193).
+          # Tauri strips the target triple, so the bundled name is plain
+          # `rustfava-server` (no arch substring to confuse the grep).
           SIDECAR="$APP_PATH/Contents/MacOS/rustfava-server"
           if [ -f "$SIDECAR" ]; then
             file "$SIDECAR"
             case "${{ matrix.target }}" in
               x86_64-*) EXPECT="x86_64" ;;
               aarch64-*) EXPECT="arm64" ;;
+              *) echo "::error::Unknown macOS target ${{ matrix.target }}"; exit 1 ;;
             esac
-            if ! file "$SIDECAR" | grep -q "$EXPECT"; then
-              echo "::error::Bundled sidecar arch mismatch: expected $EXPECT for ${{ matrix.target }}"
+            if ! file -b "$SIDECAR" | grep -qw "$EXPECT"; then
+              echo "::error::Bundled sidecar arch mismatch: expected $EXPECT for ${{ matrix.target }}, got: $(file -b "$SIDECAR")"
               exit 1
             fi
+          else
+            echo "::error::Bundled sidecar not found at $SIDECAR"
+            exit 1
           fi
 
           # Run binary directly to capture stdout/stderr and panic backtrace

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -40,7 +40,10 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             sidecar_name: rustfava-server-x86_64-unknown-linux-gnu
-          - os: macos-latest
+          # PyInstaller cannot cross-compile: it emits a binary for the
+          # runner's own arch. macos-latest is now Apple Silicon, so the x64
+          # sidecar must build on a real Intel runner (issue #193).
+          - os: macos-13
             target: x86_64-apple-darwin
             sidecar_name: rustfava-server-x86_64-apple-darwin
           - os: macos-14
@@ -130,6 +133,22 @@ jobs:
         run: |
           move dist\rustfava.exe dist\${{ matrix.sidecar_name }}
 
+      - name: Verify sidecar architecture (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          BIN="dist/${{ matrix.sidecar_name }}"
+          file "$BIN"
+          case "${{ matrix.target }}" in
+            x86_64-*) EXPECT="x86_64" ;;
+            aarch64-*) EXPECT="arm64" ;;
+            *) echo "::error::Unknown macOS target ${{ matrix.target }}"; exit 1 ;;
+          esac
+          if ! file "$BIN" | grep -q "$EXPECT"; then
+            echo "::error::Sidecar arch mismatch: expected $EXPECT for ${{ matrix.target }}"
+            exit 1
+          fi
+
       - name: Upload sidecar artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -214,7 +233,9 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             sidecar_name: rustfava-server-x86_64-unknown-linux-gnu
-          - os: macos-latest
+          # Intel runner: builds x86_64 natively so the smoke test can launch
+          # the binary (an arm64 runner has no Rosetta by default), issue #193.
+          - os: macos-13
             target: x86_64-apple-darwin
             sidecar_name: rustfava-server-x86_64-apple-darwin
           - os: macos-14
@@ -312,6 +333,20 @@ jobs:
           echo "Testing app at: $APP_PATH"
           ls -la "$APP_PATH" || { echo "App bundle not found!"; exit 1; }
           file "$BINARY"
+
+          # Verify the bundled sidecar matches the target arch (issue #193)
+          SIDECAR="$APP_PATH/Contents/MacOS/rustfava-server"
+          if [ -f "$SIDECAR" ]; then
+            file "$SIDECAR"
+            case "${{ matrix.target }}" in
+              x86_64-*) EXPECT="x86_64" ;;
+              aarch64-*) EXPECT="arm64" ;;
+            esac
+            if ! file "$SIDECAR" | grep -q "$EXPECT"; then
+              echo "::error::Bundled sidecar arch mismatch: expected $EXPECT for ${{ matrix.target }}"
+              exit 1
+            fi
+          fi
 
           # Run binary directly to capture stdout/stderr and panic backtrace
           echo "=== Launching with RUST_BACKTRACE=full ==="

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -118,6 +118,13 @@ jobs:
               print(f'Compiled {po} -> {mo}')
           "
 
+      - name: Set RUSTFAVA_VERSION from tag
+        # The spec bakes this into rustfava/_version.py so the frozen binary
+        # reports the real version without dist-info metadata (issue #191).
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: echo "RUSTFAVA_VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"
+
       - name: Build sidecar with PyInstaller
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Fixes #193 — `rustfava_1.30.13_x64.dmg` shipped a `rustfava-server` compiled for **arm64**, so the Intel desktop app fails with `Bad CPU type in executable` / `Failed to spawn rustfava-server`.

### Root cause
The bundled `rustfava-server` is the **PyInstaller sidecar**, and PyInstaller cannot cross-compile — it emits a binary for whatever architecture the runner is. The x64 `build-sidecar` job was pinned to `macos-latest`, which GitHub silently migrated to Apple Silicon. So it built an **arm64** binary, the rename step relabeled it `rustfava-server-x86_64-apple-darwin`, and it landed in the x64 dmg.

The Rust binaries (`rustfava-desktop`, `rledger`) are fine because they genuinely cross-compile via `--target` / per-target download. The smoke test only `file`d `rustfava-desktop`, never the sidecar — which is why it slipped through.

### Fix
- Pin the x64 `build-sidecar` job to `macos-13` (Intel) so PyInstaller emits a real `x86_64` binary.
- Pin the x64 `build-tauri` job to `macos-13` as well, so the macOS smoke test runs natively (an arm64 runner has no Rosetta to launch an x86_64 binary).
- **Guardrails against silent regression:** add an arch-verification step after the sidecar rename, and extend the macOS smoke test to `file`-check the bundled sidecar. A wrong-arch binary now fails CI instead of shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)