### PR TITLE
test(precision): characterize and guard the Decimal->float JSON boundary

### DIFF
--- a/tests/test_number_precision_boundary.py
+++ b/tests/test_number_precision_boundary.py
@@ -1,0 +1,92 @@
+"""Number-precision boundary characterization (Layer 2 of correctness plan).
+
+The JSON API serializes every ``Decimal`` via ``float()``
+(``core/charts.py:_json_default``), so exact ledger Decimals cross the wire as
+IEEE-754 float64. The frontend has no decimal type and renders numbers through
+``Intl.NumberFormat`` at display precision, so **typical currency values are
+unaffected in the rendered UI** — but the float rounding is visible to raw JSON
+API consumers, CSV/Excel export (``util/excel.py`` also does ``float()``), and
+column sorting, and it silently corrupts high-precision values.
+
+These tests pin the boundary so it can't regress and so a future fix is
+measurable:
+
+* ``test_typical_values_are_lossless`` — currency and reasonable crypto
+  magnitudes must survive the wire exactly (they do today: float64 holds ~15-16
+  significant digits). This guards the common case.
+* ``test_high_precision_is_lost`` — documents, as an ``xfail``, that values
+  beyond float64's precision are rounded on the wire. It flips to passing once
+  numbers are emitted exactly, which requires an exact JSON encoder (e.g.
+  ``simplejson`` with ``use_decimal``) **and** frontend decimal support — the
+  wire change alone also regenerates every snapshot, so it belongs with that
+  epic, not in isolation.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from rustfava.core.charts import dumps
+from rustfava.core.charts import loads
+
+
+def _round_trip(value: Decimal) -> Decimal:
+    """Serialize a Decimal through the real API provider and read it back."""
+    wire = dumps({"n": value})
+    return Decimal(str(loads(wire)["n"]))
+
+
+# Values a real ledger produces: 2dp fiat, 8dp crypto, large-but-bounded share
+# counts, small residues. All within float64's ~15-16 significant digits.
+LOSSLESS = [
+    "0",
+    "100.00",
+    "-1234.56",
+    "0.00801",
+    "1234567.89",
+    "0.12345678",  # 8dp crypto
+    "12345678.12345678",  # 16 significant digits
+    "-9876543.21",
+]
+
+
+@pytest.mark.parametrize("literal", LOSSLESS)
+def test_typical_values_are_lossless(literal: str) -> None:
+    """Currency and reasonable-precision values must cross the wire exactly."""
+    value = Decimal(literal)
+    assert _round_trip(value) == value
+
+
+# Values beyond float64 precision: a division result (conversions / unrealized
+# %), a large magnitude with decimals, and a high-precision large number.
+LOSSY = [
+    "88.571428571428571428571429",  # 26 significant digits (e.g. 620/7)
+    "123456789012.123456",  # 18 significant digits
+    "9999999999999999.01",  # rounds catastrophically to 1e16
+]
+
+
+@pytest.mark.parametrize("literal", LOSSY)
+@pytest.mark.xfail(
+    reason="Decimal->float64 at the JSON boundary (core/charts.py) rounds "
+    "beyond ~16 significant digits. Fixing end-to-end needs an exact JSON "
+    "encoder plus frontend decimal support (and regenerates all snapshots); "
+    "see the correctness plan. Flips green when numbers are emitted exactly.",
+    strict=True,
+)
+def test_high_precision_is_lost(literal: str) -> None:
+    """High-precision values are currently rounded on the wire (documented)."""
+    value = Decimal(literal)
+    assert _round_trip(value) == value
+
+
+def test_api_numbers_are_json_numbers_not_strings() -> None:
+    """Pin the current wire contract: report numbers serialize as JSON numbers.
+
+    A deliberate switch to exact string/tagged encoding must update this test,
+    so the wire-format change can't happen silently.
+    """
+    wire = dumps({"n": Decimal("100.00")})
+    assert '"n":100' in wire  # a bare JSON number, not "100.00" quoted


### PR DESCRIPTION
Layer 2 of the correctness plan — pins the **Decimal→float64 JSON boundary** (C2 in the analysis).

## What I found investigating C2
- The JSON API serializes every `Decimal` via `float()` (`core/charts.py:_json_default`). But the **frontend has no decimal type** (`Amount.number` is a JS `number`) and renders through `Intl.NumberFormat` at display precision — so **typical currency values are not visibly wrong in the rendered UI**. C2 is therefore a **data-fidelity** defect (CSV/Excel export via `util/excel.py`, raw JSON API consumers, column sorting, and high-precision values), not a wrong-number-in-the-report defect.
- Measured boundary: values up to ~16 significant digits round-trip exactly (all fiat, 8dp crypto); loss begins beyond that (division results like `620/7`, very large magnitudes, e.g. `9999999999999999.01 → 1e16`).
- A clean exact-wire fix is **not** a safe standalone change: stdlib `json` can't emit exact decimal literals (its C encoder ignores a `float` subclass's `__repr__`), so it needs a new dependency (`simplejson`/`use_decimal`), it regenerates **all 53 snapshots**, and it only reaches the user once the **frontend gains decimal support**. That's an epic to scope deliberately, not an isolated PR.

## What this PR does
Adds `tests/test_number_precision_boundary.py` to make the boundary explicit and regression-proof:
- **`test_typical_values_are_lossless`** — currency/crypto/bounded magnitudes must cross the wire exactly (guards the common case).
- **`test_high_precision_is_lost`** — `xfail(strict)` documenting the loss beyond ~16 sig digits; **flips green automatically** when numbers are emitted exactly, so it's the acceptance test for the eventual fix.
- **`test_api_numbers_are_json_numbers_not_strings`** — pins the current wire contract so a format switch can't happen silently.

9 passed, 3 xfailed; ruff + mypy clean.

## Recommendation
Given the UI is protected by display rounding, I'd prioritize the genuinely-wrong-number risks next (silent mixed-currency conversion totals, and cost-lot identity/ghost lots) over the exact-wire epic. This PR locks C2's boundary in the meantime.

Stacked on #202 (base branch) for green CI while `main` is red from the auto-merged bump PRs; retarget to `main` after #202 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
