### PR TITLE
fix(inventory): exclude derived number_total from cost lot identity (C3)

### DIFF
--- a/src/rustfava/rustledger/types.py
+++ b/src/rustfava/rustledger/types.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import datetime
 from dataclasses import dataclass
+from dataclasses import field
 from dataclasses import fields
 from decimal import Decimal
 from typing import Any
@@ -121,7 +122,14 @@ class RLCost:
     currency: str
     date: datetime.date | None
     label: str | None
-    number_total: Decimal | None = None
+    # ``number_total`` is derived (total = number x units) and is only used to
+    # render the ``per # total`` cost-spec syntax; beancount's booked ``Cost``
+    # has no such field. It must NOT take part in equality/hash, or two
+    # economically identical lots (one carrying a total, one not) would key to
+    # different inventory slots and never net — leaving ghost +N/-N lots that
+    # render identically (`cost_to_string` ignores number_total). See the
+    # correctness plan (C3).
+    number_total: Decimal | None = field(default=None, compare=False)
 
     @classmethod
     def from_json(

--- a/tests/test_cost_lot_identity.py
+++ b/tests/test_cost_lot_identity.py
@@ -1,0 +1,70 @@
+"""Regression: held-at-cost lots must net on economic identity, not on the
+derived ``number_total`` field (correctness plan, C3).
+
+rustledger emits a lot's cost number in three shapes — ``per_unit``, ``total``,
+and ``per_unit_from_total`` — the last populating ``RLCost.number_total`` while
+a plain ``per_unit`` leg leaves it ``None``. If ``number_total`` takes part
+in cost equality/hash, two economically identical lots key to different
+inventory slots and never cancel, so a fully-closed position shows spurious
+``+N`` / ``-N {cost}`` ghost lots that render identically (``cost_to_string``
+ignores ``number_total``) — a wrong balance the user cannot diagnose.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from decimal import Decimal
+
+import pytest
+
+beancount_loader = pytest.importorskip("beancount.loader")
+
+from rustfava.core.tree import Tree  # noqa: E402
+from rustfava.rustledger import loader as rf_loader  # noqa: E402
+
+# Buy 2 units with a *total* cost ({{100 USD}} -> per_unit_from_total, so the
+# lot carries number_total=100), then sell them per-unit ({50 USD},
+# number_total=None). Same (number, currency, date, label); differs only in the
+# derived number_total. Economically nets to an empty position.
+_LEDGER = (
+    "2020-01-01 open Assets:Stock\n"
+    "2020-01-01 open Assets:Cash USD\n"
+    '2020-02-01 * "buy at total cost"\n'
+    "  Assets:Stock   2 STK {{100 USD}}\n"
+    "  Assets:Cash  -100 USD\n"
+    '2020-02-01 * "sell at per-unit cost"\n'
+    "  Assets:Stock  -2 STK {50 USD}\n"
+    "  Assets:Cash   100 USD\n"
+)
+
+
+def test_closed_position_nets_to_empty() -> None:
+    """The fully-closed position must hold nothing (no ghost lots)."""
+    entries, errors, _ = rf_loader.load_string(_LEDGER, "<c3>")
+    assert not errors
+    balance = Tree(entries).get("Assets:Stock").balance
+    assert dict(balance) == {}, f"ghost lots remain: {dict(balance)}"
+
+
+def test_closed_position_matches_beancount() -> None:
+    """Booked position agrees with beancount's ground truth (empty)."""
+    bc_entries, _, _ = beancount_loader.load_string(_LEDGER)
+    rf_entries, _, _ = rf_loader.load_string(_LEDGER, "<c3>")
+
+    def stock_units(entries: object) -> dict[tuple[str, object], Decimal]:
+        acc: dict[tuple[str, object], Decimal] = defaultdict(Decimal)
+        for entry in entries:  # type: ignore[attr-defined]
+            for posting in getattr(entry, "postings", []):
+                if posting.account != "Assets:Stock" or posting.units is None:
+                    continue
+                cost = posting.cost
+                key = (
+                    posting.units.currency,
+                    None
+                    if cost is None
+                    else (cost.number, cost.currency, cost.date, cost.label),
+                )
+                acc[key] += Decimal(posting.units.number)
+        return {k: v for k, v in acc.items() if v != 0}
+
+    assert stock_units(rf_entries) == stock_units(bc_entries) == {}


### PR DESCRIPTION
Fixes **C3** from the correctness analysis: economically identical held-at-cost lots that fail to net, leaving ghost lots and a **wrong balance**.

## The bug
rustledger emits a lot's cost number in three shapes — `per_unit`, `total`, and `per_unit_from_total` — the last of which populates `RLCost.number_total` while a plain `per_unit` leg leaves it `None`. `RLCost` is a frozen dataclass whose `eq`/`hash` included `number_total`, and `CounterInventory` keys on the whole `RLCost` object. So a lot bought with a total cost and sold per-unit — same `(number, currency, date, label)`, differing only in the derived `number_total` — keyed to two different inventory slots and never cancelled.

Confirmed end-to-end: for
```beancount
2020-02-01 * "buy at total cost"
  Assets:Stock   2 STK {{100 USD}}
  Assets:Cash  -100 USD
2020-02-01 * "sell at per-unit cost"
  Assets:Stock  -2 STK {50 USD}
  Assets:Cash   100 USD
```
beancount reports `Assets:Stock` **empty**; rustfava showed **`+2 STK {50 USD}` and `−2 STK {50 USD}`** — two lots that render identically (`cost_to_string` ignores `number_total`), so the user sees a non-empty balance they can't diagnose.

## The fix
Mark `number_total` `compare=False` on `RLCost`, so it no longer takes part in equality/hash. It stays on the object for the `per # total` cost-spec rendering path (`beans/str.py`); beancount's booked `Cost` has no such field, so this aligns lot identity with beancount's 4-tuple `(number, currency, date, label)`.

## Tests
`tests/test_cost_lot_identity.py` — the closed position now nets to empty (fails without the fix), and a differential check confirms parity with beancount. Full suite: **500 passed, 1 skipped**.

## Note on R2 (the other item in this batch)
I investigated R2 (silent mixed-currency conversion) and it is **not** a wrong-number bug: `convert_position` returns un-convertible amounts in their *original* currency, and the tree/charts keep currencies **separate** (no code sums across currencies into one total), so they render as honest separate lines. `get_market_value`'s cost fallback (R1) is explicitly documented as intentional. Neither warranted a behavior change, so this PR is C3 only.

Stacked on #202 (base branch) for green CI while `main` is red from the auto-merged bump PRs; retarget to `main` after #202 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
