### PR TITLE
fix(test): unbreak strict mypy (differential _balance_dirs typing)

### DIFF
--- a/tests/test_differential_beancount.py
+++ b/tests/test_differential_beancount.py
@@ -18,6 +18,7 @@ import datetime
 from collections import defaultdict
 from decimal import Decimal
 from pathlib import Path
+from typing import Any
 from typing import TYPE_CHECKING
 
 import pytest
@@ -110,7 +111,7 @@ def test_booked_inventories_match_beancount(ledger: str) -> None:
         )
 
 
-def _balance_dirs(entries: Iterable[object]) -> list[object]:
+def _balance_dirs(entries: Iterable[object]) -> list[Any]:
     return [e for e in entries if type(e).__name__ in {"Balance", "RLBalance"}]
 
 


### PR DESCRIPTION
#210 merged before the mypy typing fix landed, so `main`'s `lint-python-types` job is red: `tests/test_differential_beancount.py` accesses `bal.diff_amount` on a `list[object]`. This types `_balance_dirs` as `list[Any]`. `just mypy` clean (117 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)