### PR TITLE
fix(conversion): guard cost.number is None in valuation (R3)

### DIFF
--- a/src/rustfava/core/conversion.py
+++ b/src/rustfava/core/conversion.py
@@ -29,11 +29,16 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def get_cost(pos: Position) -> Amount:
-    """Return the total cost of a Position."""
+    """Return the total cost of a Position.
+
+    A cost with no per-unit ``number`` (e.g. a bare ``{USD}`` cost the engine
+    accepts without inferring an amount) has no computable cost value, so fall
+    back to the units rather than crashing on ``None * Decimal``.
+    """
     cost_ = pos.cost
     return (
         _Amount(cost_.number * pos.units.number, cost_.currency)
-        if cost_ is not None
+        if cost_ is not None and cost_.number is not None
         else pos.units
     )
 
@@ -69,7 +74,11 @@ def get_market_value(
                 units_.number * price_number,
                 value_currency,
             )
-        return _Amount(units_.number * cost_.number, value_currency)
+        # No price: fall back to cost value, but only when the cost carries a
+        # per-unit number — a bare ``{CUR}`` cost has none, so return units
+        # rather than crashing on ``None * Decimal``.
+        if cost_.number is not None:
+            return _Amount(units_.number * cost_.number, value_currency)
     return units_
 
 

--- a/tests/test_conversion_missing_cost_number.py
+++ b/tests/test_conversion_missing_cost_number.py
@@ -1,0 +1,84 @@
+"""Valuation must never crash on a cost that lacks a per-unit number (R3).
+
+The engine accepts a bare ``{CUR}`` cost (currency only, no amount) with **no
+error**, producing a Position whose ``cost.number`` is ``None``. The valuation
+helpers compute ``cost.number * units`` and previously raised
+``TypeError: NoneType * Decimal`` — and since ``AT_COST`` runs unconditionally
+in tree serialisation / ``cap`` / ``net_profit``, one such posting 500'd the
+whole balance-sheet / net-worth render. These lock in the "valuation never
+crashes on user data" invariant and its units fallback.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from rustfava.beans.prices import RustfavaPriceMap
+from rustfava.core.conversion import AT_COST
+from rustfava.core.conversion import convert_position
+from rustfava.core.conversion import get_cost
+from rustfava.core.conversion import get_market_value
+from rustfava.core.inventory import _Amount
+from rustfava.core.inventory import _Cost
+from rustfava.core.inventory import _Position
+from rustfava.core.tree import Tree
+from rustfava.rustledger import loader as rf_loader
+
+_UNITS = _Amount(Decimal(10), "ABC")
+_D = date(2020, 1, 1)
+# A bare ``{USD}`` cost: currency only, no per-unit number. The engine really
+# produces this (cost.number None) despite the ``Decimal`` field annotation.
+_BARE_COST = _Cost(None, "USD", _D, None)  # type: ignore[arg-type]
+
+# Every cost shape valuation must tolerate, including the bare ``{USD}`` cost
+# (number=None) and a zero-unit position carrying one.
+POSITIONS = [
+    pytest.param(_Position(_UNITS, None), id="no-cost"),
+    pytest.param(
+        _Position(_UNITS, _Cost(Decimal(5), "USD", _D, None)), id="normal-cost"
+    ),
+    pytest.param(
+        _Position(_UNITS, _BARE_COST),
+        id="bare-currency-cost",
+    ),
+    pytest.param(
+        _Position(_Amount(Decimal(0), "ABC"), _BARE_COST),
+        id="zero-units-bare-cost",
+    ),
+]
+
+
+@pytest.mark.parametrize("pos", POSITIONS)
+def test_valuation_never_raises(pos: _Position) -> None:
+    """No valuation helper may raise, whatever the cost shape."""
+    prices = RustfavaPriceMap([])
+    get_cost(pos)
+    get_market_value(pos, prices)
+    convert_position(pos, "EUR", prices)
+
+
+def test_bare_currency_cost_falls_back_to_units() -> None:
+    """With no computable cost value, valuation yields the raw units."""
+    pos = _Position(_UNITS, _BARE_COST)
+    prices = RustfavaPriceMap([])
+    assert get_cost(pos) == _UNITS
+    assert get_market_value(pos, prices) == _UNITS
+
+
+def test_bare_currency_cost_balance_sheet_renders() -> None:
+    """A ledger with a bare ``{CUR}`` cost renders at cost without a 500."""
+    src = (
+        "2020-01-01 open Assets:X\n"
+        "2020-01-01 open Assets:Cash\n"
+        '2020-02-01 * "buy at unspecified cost"\n'
+        "  Assets:X   10 ABC {USD}\n"
+        "  Assets:Cash  -50 USD\n"
+    )
+    entries, _errors, _ = rf_loader.load_string(src, "<r3>")
+    node = Tree(entries).get("Assets:X")
+    # AT_COST runs unconditionally in the balance-sheet render; must not raise.
+    reduced = AT_COST.apply(node.balance)
+    assert dict(reduced) == {"ABC": Decimal(10)}


### PR DESCRIPTION
Fixes **R3** from the correctness re-assessment: a crash that 500s the balance-sheet / net-worth render.

The engine accepts a bare `{CUR}` cost (currency only, no per-unit amount) **with no error**, producing a Position whose `cost.number` is `None`. `get_cost`/`get_market_value` compute `cost.number * units` → `TypeError: NoneType * Decimal`, and since `AT_COST` runs unconditionally in tree serialise / `cap` / `net_profit`, **one such posting crashes the whole render.**

Fix: guard `cost.number is None` (no computable cost value → fall back to units), restoring the "valuation never crashes on user data" invariant.

`tests/test_conversion_missing_cost_number.py`:
- `test_valuation_never_raises` — parametrized invariant over cost shapes (no-cost, normal, bare-`{USD}`, zero-units+bare) that get_cost/get_market_value/convert_position never raise.
- units fallback + a full balance-sheet render regression.

All four bare-cost cases fail without the guard. `just mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)