### PR TITLE
feat(json): emit Decimals as exact number literals (frontend-decimal epic, step A)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ dependencies = [
     "markdown2>=2.3.0,<3",
     "ply>=3.11",
     "pydantic>=2.0",
+    # Exact Decimal JSON: emit monetary values as exact number literals rather
+    # than lossy float64 (stdlib json cannot). Keeps the wire, exports, and API
+    # consumers precise; the frontend still JSON.parses them as numbers.
+    "simplejson>=3.19",
     "watchfiles>=0.20.0",
     # Drives the rustledger WASI Preview 2 / Component-Model component
     # (rustledger #1384), the default engine. Core dep, not an extra, since the
@@ -89,6 +93,7 @@ types = [
     "typeguard>=4",
     "types-requests>=2.32.0.20250515",
     "types-setuptools>=67",
+    "types-simplejson>=3.19",
     # beangulp + beancount are now optional (#146), but the type-checked code
     # imports them — install both so mypy can resolve the stubs (previously
     # beancount came in transitively via the beangulp core dep).

--- a/src/rustfava/core/charts.py
+++ b/src/rustfava/core/charts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections import defaultdict
 from dataclasses import dataclass
 from dataclasses import fields
@@ -12,13 +13,10 @@ from re import Pattern
 from typing import Any
 from typing import TYPE_CHECKING
 
-import json
-
+import simplejson
 from flask.json.provider import JSONProvider
 
 from rustfava.beans.abc import Position
-from rustfava.rustledger.constants import Booking
-from rustfava.rustledger.constants import MISSING
 from rustfava.beans.abc import Transaction
 from rustfava.beans.account import account_tester
 from rustfava.beans.flags import FLAG_UNREALIZED
@@ -26,6 +24,8 @@ from rustfava.beans.helpers import slice_entry_dates
 from rustfava.core.conversion import conversion_from_str
 from rustfava.core.inventory import CounterInventory
 from rustfava.core.module_base import FavaModule
+from rustfava.rustledger.constants import Booking
+from rustfava.rustledger.constants import MISSING
 from rustfava.util import listify
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -43,9 +43,11 @@ ZERO = Decimal()
 
 
 def _json_default(o: Any) -> Any:
-    """Specific serialisation for some data types."""
-    if isinstance(o, Decimal):
-        return float(o)
+    """Specific serialisation for some data types.
+
+    ``Decimal`` is handled natively by ``simplejson`` (``use_decimal``), which
+    emits it as an exact number literal instead of a lossy ``float``.
+    """
     if isinstance(o, (date, Booking, Position)):
         return str(o)
     if isinstance(o, (set, frozenset)):
@@ -60,9 +62,13 @@ def _json_default(o: Any) -> Any:
 
 
 def dumps(obj: Any, **_kwargs: Any) -> str:
-    """Dump as a JSON string."""
-    return json.dumps(
-        obj, sort_keys=True, separators=(",", ":"), default=_json_default
+    """Dump as a JSON string, emitting Decimals as exact number literals."""
+    return simplejson.dumps(
+        obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_default,
+        use_decimal=True,
     )
 
 
@@ -75,8 +81,12 @@ class RustfavaJSONProvider(JSONProvider):
     """Use custom JSON encoder and decoder."""
 
     def dumps(self, obj: Any, **_kwargs: Any) -> str:  # noqa: D102
-        return json.dumps(
-            obj, sort_keys=True, separators=(",", ":"), default=_json_default
+        return simplejson.dumps(
+            obj,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=_json_default,
+            use_decimal=True,
         )
 
     def loads(self, s: str | bytes, **_kwargs: Any) -> Any:  # noqa: D102

--- a/tests/test_number_precision_boundary.py
+++ b/tests/test_number_precision_boundary.py
@@ -1,25 +1,16 @@
-"""Number-precision boundary characterization (Layer 2 of correctness plan).
+"""Number-precision at the JSON boundary (Layer 2 of the correctness plan).
 
-The JSON API serializes every ``Decimal`` via ``float()``
-(``core/charts.py:_json_default``), so exact ledger Decimals cross the wire as
-IEEE-754 float64. The frontend has no decimal type and renders numbers through
-``Intl.NumberFormat`` at display precision, so **typical currency values are
-unaffected in the rendered UI** — but the float rounding is visible to raw JSON
-API consumers, CSV/Excel export (``util/excel.py`` also does ``float()``), and
-column sorting, and it silently corrupts high-precision values.
+The JSON API now serialises every ``Decimal`` as an **exact number literal**
+(``core/charts.py`` uses ``simplejson`` with ``use_decimal``), so the wire
+carries full precision — a decimal-aware consumer (an exact API client, or a
+future frontend decimal type) recovers the exact ledger value, and
+custom/budget amounts no longer leak as ``float`` (R8).
 
-These tests pin the boundary so it can't regress and so a future fix is
-measurable:
-
-* ``test_typical_values_are_lossless`` — currency and reasonable crypto
-  magnitudes must survive the wire exactly (they do today: float64 holds ~15-16
-  significant digits). This guards the common case.
-* ``test_high_precision_is_lost`` — documents, as an ``xfail``, that values
-  beyond float64's precision are rounded on the wire. It flips to passing once
-  numbers are emitted exactly, which requires an exact JSON encoder (e.g.
-  ``simplejson`` with ``use_decimal``) **and** frontend decimal support — the
-  wire change alone also regenerates every snapshot, so it belongs with that
-  epic, not in isolation.
+A float-parsing consumer (plain ``JSON.parse`` in the browser, or stdlib
+``json.loads``) still narrows to float64 on read — that residual is the
+frontend-decimal step, tracked separately. The frontend renders through
+``Intl.NumberFormat`` at display precision, so typical values are unaffected in
+the UI regardless.
 """
 
 from __future__ import annotations
@@ -27,66 +18,60 @@ from __future__ import annotations
 from decimal import Decimal
 
 import pytest
+import simplejson
 
 from rustfava.core.charts import dumps
 from rustfava.core.charts import loads
 
 
-def _round_trip(value: Decimal) -> Decimal:
-    """Serialize a Decimal through the real API provider and read it back."""
-    wire = dumps({"n": value})
-    return Decimal(str(loads(wire)["n"]))
+def _wire_value(value: Decimal) -> Decimal:
+    """The exact Decimal an exact consumer recovers from the wire."""
+    parsed = simplejson.loads(dumps({"n": value}), use_decimal=True)
+    return Decimal(parsed["n"])
 
 
-# Values a real ledger produces: 2dp fiat, 8dp crypto, large-but-bounded share
-# counts, small residues. All within float64's ~15-16 significant digits.
-LOSSLESS = [
+# A spread of real-ledger and adversarial magnitudes: 2dp fiat, 8dp crypto,
+# division results (conversions / unrealized %), large magnitudes, and values
+# well beyond float64's ~16 significant digits.
+VALUES = [
     "0",
     "100.00",
     "-1234.56",
     "0.00801",
-    "1234567.89",
     "0.12345678",  # 8dp crypto
     "12345678.12345678",  # 16 significant digits
-    "-9876543.21",
-]
-
-
-@pytest.mark.parametrize("literal", LOSSLESS)
-def test_typical_values_are_lossless(literal: str) -> None:
-    """Currency and reasonable-precision values must cross the wire exactly."""
-    value = Decimal(literal)
-    assert _round_trip(value) == value
-
-
-# Values beyond float64 precision: a division result (conversions / unrealized
-# %), a large magnitude with decimals, and a high-precision large number.
-LOSSY = [
-    "88.571428571428571428571429",  # 26 significant digits (e.g. 620/7)
+    "88.571428571428571428571429",  # 26 sig digits (e.g. 620/7)
     "123456789012.123456",  # 18 significant digits
-    "9999999999999999.01",  # rounds catastrophically to 1e16
+    "9999999999999999.01",  # would round to 1e16 as a float
 ]
 
 
-@pytest.mark.parametrize("literal", LOSSY)
-@pytest.mark.xfail(
-    reason="Decimal->float64 at the JSON boundary (core/charts.py) rounds "
-    "beyond ~16 significant digits. Fixing end-to-end needs an exact JSON "
-    "encoder plus frontend decimal support (and regenerates all snapshots); "
-    "see the correctness plan. Flips green when numbers are emitted exactly.",
-    strict=True,
-)
-def test_high_precision_is_lost(literal: str) -> None:
-    """High-precision values are currently rounded on the wire (documented)."""
+@pytest.mark.parametrize("literal", VALUES)
+def test_values_cross_the_wire_exactly(literal: str) -> None:
+    """Every value survives the wire exactly, at any precision."""
     value = Decimal(literal)
-    assert _round_trip(value) == value
+    assert _wire_value(value) == value
+
+
+@pytest.mark.parametrize(
+    "literal", ["88.571428571428571428571429", "9999999999999999.01"]
+)
+def test_float_parsing_consumer_still_rounds(literal: str) -> None:
+    """A float-parsing read still narrows to float64 (the residual gap).
+
+    Documents that plain ``json.loads``/``JSON.parse`` rounds high-precision
+    values — the frontend-decimal step. Flips (this test's premise breaks) if a
+    decimal-aware parser is adopted on the read side.
+    """
+    value = Decimal(literal)
+    assert Decimal(str(loads(dumps({"n": value}))["n"])) != value
 
 
 def test_api_numbers_are_json_numbers_not_strings() -> None:
-    """Pin the current wire contract: report numbers serialize as JSON numbers.
+    """Report numbers must serialise as JSON numbers, not quoted strings.
 
-    A deliberate switch to exact string/tagged encoding must update this test,
-    so the wire-format change can't happen silently.
+    A switch to string/tagged encoding must update this test, so the
+    wire-format contract can't change silently.
     """
     wire = dumps({"n": Decimal("100.00")})
-    assert '"n":100' in wire  # a bare JSON number, not "100.00" quoted
+    assert '"n":100.00' in wire  # exact number literal, not "100.00" quoted

--- a/uv.lock
+++ b/uv.lock
@@ -1405,6 +1405,7 @@ dependencies = [
     { name = "markdown2" },
     { name = "ply" },
     { name = "pydantic" },
+    { name = "simplejson" },
     { name = "wasmtime" },
     { name = "watchfiles" },
     { name = "werkzeug" },
@@ -1436,6 +1437,7 @@ dev = [
     { name = "typeguard" },
     { name = "types-requests" },
     { name = "types-setuptools" },
+    { name = "types-simplejson" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -1464,6 +1466,7 @@ types = [
     { name = "typeguard" },
     { name = "types-requests" },
     { name = "types-setuptools" },
+    { name = "types-simplejson" },
 ]
 
 [package.metadata]
@@ -1482,6 +1485,7 @@ requires-dist = [
     { name = "pyexcel", marker = "extra == 'excel'", specifier = ">=0.5" },
     { name = "pyexcel-ods3", marker = "extra == 'excel'", specifier = ">=0.5" },
     { name = "pyexcel-xlsx", marker = "extra == 'excel'", specifier = ">=0.5" },
+    { name = "simplejson", specifier = ">=3.19" },
     { name = "wasmtime", specifier = ">=45,<46" },
     { name = "watchfiles", specifier = ">=0.20.0" },
     { name = "werkzeug", specifier = ">=2.2,<4" },
@@ -1503,6 +1507,7 @@ dev = [
     { name = "typeguard", specifier = ">=4" },
     { name = "types-requests", specifier = ">=2.32.0.20250515" },
     { name = "types-setuptools", specifier = ">=67" },
+    { name = "types-simplejson", specifier = ">=3.19" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.6" },
@@ -1532,6 +1537,7 @@ types = [
     { name = "typeguard", specifier = ">=4" },
     { name = "types-requests", specifier = ">=2.32.0.20250515" },
     { name = "types-setuptools", specifier = ">=67" },
+    { name = "types-simplejson", specifier = ">=3.19" },
 ]
 
 [[package]]
@@ -1541,6 +1547,48 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "simplejson"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/2a/54837395a3487c725669428d513293612a48d82b95a0642c936932e5d898/simplejson-4.1.1.tar.gz", hash = "sha256:c08eb9f7a90f77ae470e19a07472e9a79ebc0d1c2315d86a72767665bd5ba79f", size = 118860, upload-time = "2026-04-24T19:24:59.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/a9/47b445eeb559c9593453a0648e0fd6d08e8adff64dd5e5ced66726da8a09/simplejson-4.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dff52fc7af272e84fc21cc5a06c927c823ca6ae00af14f3b0d7707b42775ed98", size = 113160, upload-time = "2026-04-24T19:23:26.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/cb72db31523c164dea5dc55b02dad065a40c478856bc7534b279d2b51906/simplejson-4.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:971aed0647ad6e840a3943bec812fcda5f2d26a5497a4981d1fb49aa4f9a396c", size = 91521, upload-time = "2026-04-24T19:23:27.572Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e5/54cb7c50ad5fdc1e0a86b7df4b135c2cbd5c4623605aa94466659098e8da/simplejson-4.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:249e2e220aa6d9b9d936bde84eb7bf79d5b6c5a8273c6e411f8b1635a9073f2d", size = 91407, upload-time = "2026-04-24T19:23:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/21a3ede87f0bf82d6c7bcb90480d50a6490eb974c6ab20881188e440957c/simplejson-4.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e5cdd6a5d52299f345c15ab5678cc4249e24f383f361d986afbc3c7072a6b6b", size = 192451, upload-time = "2026-04-24T19:23:30.56Z" },
+    { url = "https://files.pythonhosted.org/packages/59/df/9903edd3102bf0b5984edfcb90c88612330996efa3b4fbf8a971d6e17839/simplejson-4.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642cec364e0676e2d5a73fa4d31d0c7c55886997caa2fde24e8292ca44d32728", size = 189015, upload-time = "2026-04-24T19:23:32.647Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cd/33230927a780e1398b857e3944abb914556994d252b1d765ae40d112cb25/simplejson-4.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:76fe296ca1df23d290033f10aaacf534fd1b3e3007e7f9ff8aa68b21413aaa78", size = 196658, upload-time = "2026-04-24T19:23:34.563Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/84/2c5a7444eb53e9a86d3738299bffddd9f53aeed799ded2f45368221fdb19/simplejson-4.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f0ad25b7dc4e0fb23858355819f2e994f1a5badcdcde8737eac7921c2f1ed2a", size = 185967, upload-time = "2026-04-24T19:23:36.191Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/454378e06d059cd412a7ed5d87fb6d29fd5b60f13a4d89fc1f764ff434df/simplejson-4.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a59ebd0533f03fd06ff0c42ba0f02d93cbcdd7944922bf3b93911327a95b901f", size = 193940, upload-time = "2026-04-24T19:23:38.151Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d5/a15bf915f623a2c5a079d6e3be8256fdb8ef06f110669493a09b9d6933e0/simplejson-4.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bccbf4419676b517939852e5aeff2af6aee4dc046881c67a1581fa6f1cb01abd", size = 189795, upload-time = "2026-04-24T19:23:40.139Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c9/37212ae7dc4b607f0978c408e8633f05c810884e054c33113184c6c2c8a2/simplejson-4.1.1-cp313-cp313-win32.whl", hash = "sha256:6c845363eb5fd166fb7c72243da38f4fcfde666ede7fdf2cc6fd7762894626f7", size = 88773, upload-time = "2026-04-24T19:23:41.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a5/c7a0a47883a9015b54c9d8a4b62f2aba17bd4335b1787b9b8a0fc2fa6d52/simplejson-4.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:104d8324c34f25b4b90800bc5fa363780cbc3d8496aef061cba7ce1af9162270", size = 90888, upload-time = "2026-04-24T19:23:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/4a118a6a92eb33bb08c8e2fe7ec85cb96f0673491bb2b829930831ee4fbe/simplejson-4.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ed7473602b6625de793b6acba49aa949f144a475f538792067e4cf2fda2071f5", size = 110492, upload-time = "2026-04-24T19:23:44.957Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/84d160e9fa8cada1e0a9381cae4fa81eecd573577a5b34366d8ced59bdf7/simplejson-4.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:225c9caa324c5b554d009fb9cac22aee7711e71bd96f487938c659af467e828e", size = 90152, upload-time = "2026-04-24T19:23:46.355Z" },
+    { url = "https://files.pythonhosted.org/packages/68/31/9a5432c433a7671107182cdc9a20ea78a70f99c4e5334aa54b6d4d0d79ed/simplejson-4.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:95407269340c7f22f09776ea7b717a52cf56cfcf119b5e45f66faa4a26445bea", size = 90115, upload-time = "2026-04-24T19:23:47.743Z" },
+    { url = "https://files.pythonhosted.org/packages/78/91/3635cdb13318cb0a328abaa69e2b91251caad39d6779aa308098f341f6cb/simplejson-4.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3851658d642c1184d2023f0e6c9ce44a21eb1629e74e7c84ef956b128841fe12", size = 184036, upload-time = "2026-04-24T19:23:49.472Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/149b6ec5393f6849d98c59cadba888b710a8ef4b805ab91e11a566960d40/simplejson-4.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95a3bb0f78e85f4937f99092239f2011ce06f0f2d803df5c299cc05abbeae008", size = 180543, upload-time = "2026-04-24T19:23:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7c/a5d968d0b527a748b667e62bea94309ccbcb1e2b108e8f0cf8547efaa12b/simplejson-4.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbfdaa7c0603f75b7b14b211b7f2be44696d4e26833ad2d91d5c87bf5fb9a920", size = 188725, upload-time = "2026-04-24T19:23:52.995Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e3/6a8d11181d587ef00e2db9112357e6832111e56dd56b01b5c11758a1965d/simplejson-4.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e3c584071dced8c21b4689f0254303521daeb9b5bc1f4289755d71fa3cb0d3", size = 177492, upload-time = "2026-04-24T19:23:54.581Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e3/8b0eb8b06e8198cfbd1270487da163d0093df05cc4f557350cd65e2f7e79/simplejson-4.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:036a27bd0469b9d79557cbddb392969f876cd7f278cfbd0fba81534927a06575", size = 185281, upload-time = "2026-04-24T19:23:56.13Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/5f/64990f07ec9e2cb1a814c674e2e21b5693207f74ac70eb72151b847ea4e6/simplejson-4.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b70bfd2f67f3351baba08aa3ae9233c83f21fd95ae5e6b3d0ecb8c647929112f", size = 181848, upload-time = "2026-04-24T19:23:57.92Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/bbc1bc0447f339f79f99ab8c37f7f037cb2f1f93af75d6a4d553096bb0c3/simplejson-4.1.1-cp314-cp314-win32.whl", hash = "sha256:37233c72ce88d06acb92747347742b3c07871eba6789f060c179c9302dde8efe", size = 88761, upload-time = "2026-04-24T19:23:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/18/72/ec1b5cbdcb140c132e6c7bdf99bd73e4f675439e77126c88f472fcffa09c/simplejson-4.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:cc0442dea71cd9cbf30a0b8b9929ab5aa6c02c0443a3d977351e6ec5bada4388", size = 91018, upload-time = "2026-04-24T19:24:00.85Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/4fa437f68ff72219bac3bf3d050de9c6265691f3a170e16954bd69d7cddd/simplejson-4.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c996a4d38290c515af347740659ce095b425449c164a5c9fa3977caa6eff5dbe", size = 113919, upload-time = "2026-04-24T19:24:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/59de041d09eb4a9577f7015d7263c32095dfb7fde49717dff62145d89809/simplejson-4.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c65c763fb20d7ca113c1c14dce2fc04a0fc3a57aceff533d6fdac707c7bffb40", size = 91904, upload-time = "2026-04-24T19:24:03.812Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8e/46bb345d540f6eb31427d984a4e518cdb182d0621814fee4fee045e8815b/simplejson-4.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0da5c9f57206ee7ef280ff7f1d924937b0a64f9a271a5ef371a2ecdbebba7421", size = 91752, upload-time = "2026-04-24T19:24:05.622Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e2/1b2ce97f068835eb3d253c116a4df7a3f436b7bf2fb5ff1ba29287e8b0ec/simplejson-4.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ea3426e786425d10e9e82f8a6eda74a7d6eb10d99165ac3d0d3bbcb65c0ea343", size = 214021, upload-time = "2026-04-24T19:24:07.447Z" },
+    { url = "https://files.pythonhosted.org/packages/48/70/d93e556df6a0786298644a7c08304fcbeddc248325f23f38acbebeb21165/simplejson-4.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d75cea7a1025edd7e439b2966b3d977c45b5b899e2adaf422811b3ac702ed9fb", size = 213530, upload-time = "2026-04-24T19:24:09.289Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a5/c93bf305b9f00d7259e09e713d60e75bd0f7f53da970f716ab90491770e7/simplejson-4.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:63c2ada8e58f266491f19eed2eeeb7c25c6141e52f8f9e820f6bb94156cf8dbc", size = 218282, upload-time = "2026-04-24T19:24:10.991Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/20/a9b5d2e27ec44b069ee251bd55544fc76929a067107b1050001566ba86f3/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d1fffb56305c5b475ee746cf9e04f97423ba5aaacd292dc1255bd75b1d3b124b", size = 209249, upload-time = "2026-04-24T19:24:12.662Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e4/e06ee682ed5df67592181f5ecb062e35878967e27f5b6e087237d4548d95/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a6525ec733f43d0541206cffa64fd2aad5a7ae3eb76566aff49cd4db6382209a", size = 213963, upload-time = "2026-04-24T19:24:14.302Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/9f/1e160e4cd8cdbf062bf6a454cdf814dc7a48eb47e566fdb8f80ccb202605/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:861e393260508efa64d8805a8e49c416c3484907e3f146ce966c69552b49b9a3", size = 210474, upload-time = "2026-04-24T19:24:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e6/cecd913df322df5bbe7ebb8ba39e0708e505a165553900da8a7761026d6f/simplejson-4.1.1-cp314-cp314t-win32.whl", hash = "sha256:d083b89d30948a751d3d97476c2ed91e4caaa24a1a1459bdbadb8876242c71fe", size = 91134, upload-time = "2026-04-24T19:24:17.635Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/f540dde99cc1d393bd062ab3b5735b777561a5d8f8a5f2e241164444d77a/simplejson-4.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4cbb299d0528ec0447fe366d8c9641860e28f997a62730690fef905f1f41046e", size = 94467, upload-time = "2026-04-24T19:24:19.109Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6a/8b74c52ffd33dbbde00fe7251fee6a0acdc8cea33f7a43805aed258fb79b/simplejson-4.1.1-py3-none-any.whl", hash = "sha256:2ce92b3748f02423e26d2bfb636fb9d7a8f67c8f5854dcae69d350d123b2eee2", size = 69195, upload-time = "2026-04-24T19:24:57.962Z" },
 ]
 
 [[package]]
@@ -1610,6 +1658,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/38/bc/73c2c27e047e42f114ac50fb3bdef986c56cbdb68096f8690eeafb839a93/types_setuptools-82.0.0.20260518.tar.gz", hash = "sha256:3b743cfe63d0981ea4c15b90710fc1ed41e3464a537d51e705be514e891c1d07", size = 44999, upload-time = "2026-05-18T06:02:55.642Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/8f/d5e2d493f09a7a98c95619edda1cb37cee377626c0a869d53274c26f2858/types_setuptools-82.0.0.20260518-py3-none-any.whl", hash = "sha256:31c04a62b57a653a5021caf191be0f10f70df890f813b51f02bab3969d300f20", size = 68444, upload-time = "2026-05-18T06:02:54.582Z" },
+]
+
+[[package]]
+name = "types-simplejson"
+version = "3.20.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/e4/f8ecdc3529688ad058b0496f67a1bdfbd2576c3669e1c478b6347b12cb7e/types_simplejson-3.20.0.20260518.tar.gz", hash = "sha256:298c5b2fc2df3eb128d2077abd5bd1f5b0419dcf72fdf0551b2af2f03b1ff2b3", size = 10777, upload-time = "2026-05-18T06:04:39.57Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/41/16937326596bec6283a51cc901c701a964019569b861ac5f88128bc98b43/types_simplejson-3.20.0.20260518-py3-none-any.whl", hash = "sha256:f4792dbc1ab049fcaee5d99ca950bd6468ea462fe79af25fe8ca08b6bee313ac", size = 10421, upload-time = "2026-05-18T06:04:38.706Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Step A of the frontend-decimal epic** — closes the *wire* half of C2 and fixes **R8**, and it landed far smaller than the original "regenerate 53 snapshots" estimate.

## What
The JSON provider serialized every `Decimal` via `float()` (`core/charts.py`), so monetary values crossed the wire as lossy float64. Switch `dumps` to `simplejson` with `use_decimal=True` → Decimals emit as **exact number literals** (`88.571428571428571428571428571` instead of `88.57142857142857`).

- **Exact wire** — a decimal-aware API consumer recovers the exact ledger value; Python's lossy `float()` intermediate is gone.
- **R8 fixed** — custom/budget amount values are now exact, consistent with Balance/Price (which already stringified).
- **Transparent to the frontend** — exact literals are valid JSON numbers, so `JSON.parse` still reads them (float64 for display, same as today). **No frontend change, no snapshot churn** (the snapshot fixture re-parses to float before comparing).

## Scope & verification
Diff is **3 files** (`charts.py`, `pyproject.toml`, `uv.lock`) + the boundary test. Full py suite **100% coverage, 544 passed**; JS **86 pass**; `just mypy` clean.

`test_number_precision_boundary` rewritten: every value now crosses the wire exactly (the old high-precision `xfail` flips to passing), with one test documenting the **residual** — a plain `JSON.parse`/`json.loads` read still narrows to float64.

## To weigh
- **New core dependency: `simplejson`** (+ `types-simplejson` stub). It's the clean way to emit exact Decimal literals (stdlib `json` can't — its C encoder ignores a float subclass's `__repr__`). `loads` stays stdlib `json`, so request parsing is unaffected.
- **Step B** (exact numbers *displayed* in the browser) is the remaining, larger part: a frontend decimal library on the read side. Lower value since the UI already rounds normal values for display; worth doing only if high-precision display matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)