### PR TITLE
fix(excel): keep exact Decimal in CSV/spreadsheet export

### DIFF
--- a/src/rustfava/util/excel.py
+++ b/src/rustfava/util/excel.py
@@ -96,7 +96,10 @@ def _row_to_pyexcel(row: ResultRow, header: list[Column]) -> list[str]:
             continue
         type_ = column.datatype
         if type_ is Decimal:
-            result.append(float(value))
+            # Keep the exact Decimal: CSV writes str(Decimal) losslessly, and
+            # pyexcel accepts it for xlsx/ods (those cells are float64 by the
+            # format anyway). float() here would corrupt CSV precision.
+            result.append(value)
         elif type_ is int:
             result.append(value)
         elif type_ in (set, frozenset) or isinstance(value, (set, frozenset)):

--- a/tests/test_util_excel.py
+++ b/tests/test_util_excel.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
 from typing import TYPE_CHECKING
 
 import pytest
 
+from rustfava.rustledger.query import ColumnDescription
 from rustfava.rustledger.query import connect
 from rustfava.util import excel
 
@@ -40,6 +42,18 @@ def test_to_csv(example_ledger: RustfavaLedger) -> None:
     assert types
     assert rows
     assert excel.to_csv(types, rows)
+
+
+def test_to_csv_preserves_exact_decimal() -> None:
+    """CSV export must keep a Decimal exact — no lossy float() (R8-adjacent).
+
+    CSV is text, so it can carry full precision; the old float() rounded
+    high-precision values on the way out.
+    """
+    exact = Decimal("88.571428571428571428571428571")
+    types = [ColumnDescription("amount", Decimal)]
+    out = excel.to_csv(types, [(exact,)]).getvalue().decode("utf-8")
+    assert "88.571428571428571428571428571" in out
 
 
 @pytest.mark.skipif(not excel.HAVE_EXCEL, reason="pyexcel not installed")


### PR DESCRIPTION
The last genuinely-lossy user-facing number path (companion to the exact-JSON-wire PR #215).

Query export coerced `Decimal` cells with `float()` before writing. **CSV is text** and can carry full precision, so this rounded high-precision values on the way out (a 28-digit conversion result became `88.57142857142857`).

Fix: keep the `Decimal` — `csv.writer` `str()`s it losslessly. `pyexcel` accepts it for `.xlsx`/`.ods` (verified), and those cells are float64 by the format regardless, so Excel/ODS are unchanged.

`test_to_csv_preserves_exact_decimal` fails without the fix. (excel.py is coverage-omitted; the test still guards the behavior.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)