### PR TITLE
fix(rustledger): complete the v0.19.0 upgrade — host-side GPG decryption (WIT 3.2.0)

### DIFF
--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import threading
 import urllib.request
@@ -55,7 +56,7 @@ from rustfava.rustledger.engine import RustledgerError
 # IDs embed the full WIT package version (independent of the rustledger release
 # version), so a WIT bump means updating ``_WIT_VERSION`` here — a mismatch
 # makes ``get_export_index`` return ``None`` and every call fail.
-_WIT_VERSION = "3.1.0"
+_WIT_VERSION = "3.2.0"
 _LEDGER = f"rustledger:ledger/ledger@{_WIT_VERSION}"
 _BUILDER = f"rustledger:ledger/builder@{_WIT_VERSION}"
 _UTIL = f"rustledger:ledger/util@{_WIT_VERSION}"
@@ -66,6 +67,47 @@ _COMPONENT_WASM_URL = (
     "https://github.com/rustledger/rustledger/releases/download/"
     f"{RUSTLEDGER_VERSION}/rustledger-ffi-component-{RUSTLEDGER_VERSION}.wasm"
 )
+
+
+# -- host capability: GPG decryption (WIT 3.2.0, rustledger#1667) -------------
+#
+# A WASI guest can neither spawn ``gpg`` nor reach the user's keyring, so the
+# component imports ``rustledger:ledger/host@<wit>`` with a single
+# ``decrypt: func(ciphertext: list<u8>) -> result<string, string>`` and calls
+# it when it detects an encrypted (``.gpg``/``.asc``) input. The host runs the
+# system ``gpg --batch --decrypt`` (keyring + gpg-agent for passphrases),
+# matching rustledger's native loader semantics.
+_HOST = f"rustledger:ledger/host@{_WIT_VERSION}"
+
+
+def _host_decrypt(_store: Any, ciphertext: Any) -> Variant:
+    try:
+        proc = subprocess.run(
+            ["gpg", "--batch", "--decrypt"],  # noqa: S607
+            input=bytes(ciphertext),
+            capture_output=True,
+            check=False,
+        )
+    except OSError as exc:
+        return Variant(tag="err", payload=f"failed to run gpg: {exc}")
+    if proc.returncode != 0:
+        return Variant(
+            tag="err",
+            payload=proc.stderr.decode("utf-8", "replace").strip()
+            or f"gpg exited with status {proc.returncode}",
+        )
+    try:
+        return Variant(tag="ok", payload=proc.stdout.decode("utf-8"))
+    except UnicodeDecodeError as exc:
+        return Variant(
+            tag="err", payload=f"decrypted content is not valid UTF-8: {exc}"
+        )
+
+
+def _define_host_interface(linker: Linker) -> None:
+    """Register the ``host`` interface the component imports (WIT >= 3.2.0)."""
+    with linker.root() as root, root.add_instance(_HOST) as host:
+        host.add_func("decrypt", _host_decrypt)
 
 
 def _default_wasm_path() -> Path:
@@ -575,6 +617,7 @@ class RustledgerComponentEngine:
         store.set_wasi(wasi)
         linker = Linker(self._engine)
         linker.add_wasip2()
+        _define_host_interface(linker)
         inst = linker.instantiate(store, self._component)
         return store, inst
 
@@ -617,7 +660,7 @@ class RustledgerComponentEngine:
     # -- public API (mirrors RustledgerEngine) -----------------------------
 
     def version(self) -> str:
-        """Return the component's ``api_version`` string (e.g. ``"2.1"``)."""
+        """Return the component's ``api_version`` string (e.g. ``"3.2"``)."""
         return self._call(_LEDGER, "version", [])
 
     def load(

--- a/tests/test_encrypted_ledger.py
+++ b/tests/test_encrypted_ledger.py
@@ -11,6 +11,7 @@ success), and detection (``is-encrypted``) must work regardless.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -40,6 +41,8 @@ def test_undecryptable_ledger_fails_cleanly() -> None:
 
 def test_encrypted_ledger_roundtrip(tmp_path: Path) -> None:
     """An encrypted ledger the keyring CAN decrypt loads end-to-end."""
+    if shutil.which("gpg") is None:
+        pytest.skip("gpg not installed")
     gnupg = tmp_path / "gnupg"
     gnupg.mkdir(mode=0o700)
     env = {"GNUPGHOME": str(gnupg), "PATH": "/usr/bin:/bin"}
@@ -130,3 +133,31 @@ def test_host_decrypt_non_utf8(monkeypatch: pytest.MonkeyPatch) -> None:
     result = _host_decrypt(None, b"data")
     assert result.tag == "err"
     assert "not valid UTF-8" in str(result.payload)
+
+
+def test_host_decrypt_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful gpg output surfaces as an ok result with the plaintext."""
+
+    class FakeProc:
+        returncode = 0
+        stdout = b"2026-01-01 open Assets:Cash\n"
+        stderr = b""
+
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: FakeProc())
+    result = _host_decrypt(None, b"ciphertext")
+    assert result.tag == "ok"
+    assert "Assets:Cash" in str(result.payload)
+
+
+def test_host_decrypt_gpg_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A gpg failure surfaces its stderr as the err payload."""
+
+    class FakeProc:
+        returncode = 2
+        stdout = b""
+        stderr = b"gpg: decryption failed: No secret key\n"
+
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: FakeProc())
+    result = _host_decrypt(None, b"ciphertext")
+    assert result.tag == "err"
+    assert "No secret key" in str(result.payload)

--- a/tests/test_encrypted_ledger.py
+++ b/tests/test_encrypted_ledger.py
@@ -41,14 +41,15 @@ def test_undecryptable_ledger_fails_cleanly() -> None:
 
 def test_encrypted_ledger_roundtrip(tmp_path: Path) -> None:
     """An encrypted ledger the keyring CAN decrypt loads end-to-end."""
-    if shutil.which("gpg") is None:
+    gpg = shutil.which("gpg")
+    if gpg is None:
         pytest.skip("gpg not installed")
     gnupg = tmp_path / "gnupg"
     gnupg.mkdir(mode=0o700)
-    env = {"GNUPGHOME": str(gnupg), "PATH": "/usr/bin:/bin"}
+    env = {"GNUPGHOME": str(gnupg), "PATH": os.environ.get("PATH", "")}
     gen = subprocess.run(
-        [  # noqa: S607
-            "gpg",
+        [
+            gpg,
             "--batch",
             "--pinentry-mode",
             "loopback",
@@ -77,8 +78,8 @@ def test_encrypted_ledger_roundtrip(tmp_path: Path) -> None:
     )
     ledger = tmp_path / "ledger.beancount.gpg"
     enc = subprocess.run(
-        [  # noqa: S607
-            "gpg",
+        [
+            gpg,
             "--batch",
             "--encrypt",
             "--recipient",

--- a/tests/test_encrypted_ledger.py
+++ b/tests/test_encrypted_ledger.py
@@ -1,19 +1,24 @@
 """GPG-encrypted ledger handling.
 
-The engine detects encrypted files (``is-encrypted``) but currently cannot
-*decrypt* them: the WASI component only pre-opens the ledger's own
-directory, so it cannot reach the GPG keyring, and load fails with a clear error
-(rustledger upstream). This guards two things that must hold regardless:
-detection works, and an undecryptable ledger fails **cleanly** (an error in the
-result, never a crash or silently-empty success).
+Since rustledger v0.19.0 (WIT 3.2.0) the WASI component delegates decryption to
+the host: rustfava provides a ``decrypt`` capability that runs the system
+``gpg --batch --decrypt`` (keyring + gpg-agent). Encrypted ledgers therefore
+load end-to-end when the keyring can decrypt them; when it cannot, loading must
+fail **cleanly** (an error in the result, never a crash or silently-empty
+success), and detection (``is-encrypted``) must work regardless.
 """
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from rustfava.rustledger import is_encrypted_file
 from rustfava.rustledger import loader
+from rustfava.rustledger.component_engine import _host_decrypt
 
 _ENCRYPTED = Path(__file__).parent / "ledgers" / "encrypted.beancount.gpg"
 
@@ -24,10 +29,104 @@ def test_encrypted_file_is_detected() -> None:
 
 
 def test_undecryptable_ledger_fails_cleanly() -> None:
-    """Loading an undecryptable ledger yields an error, not a crash."""
+    """A ledger the keyring cannot decrypt yields an error, not a crash."""
     entries, errors, _ = loader.load_uncached(str(_ENCRYPTED))
     assert not entries
     assert errors
     assert any(
         "decrypt" in str(getattr(e, "message", e)).lower() for e in errors
     )
+
+
+def test_encrypted_ledger_roundtrip(tmp_path: Path) -> None:
+    """An encrypted ledger the keyring CAN decrypt loads end-to-end."""
+    gnupg = tmp_path / "gnupg"
+    gnupg.mkdir(mode=0o700)
+    env = {"GNUPGHOME": str(gnupg), "PATH": "/usr/bin:/bin"}
+    gen = subprocess.run(
+        [  # noqa: S607
+            "gpg",
+            "--batch",
+            "--pinentry-mode",
+            "loopback",
+            "--passphrase",
+            "",
+            "--quick-gen-key",
+            "rustfava-test@example.invalid",
+            "default",
+            "default",
+        ],
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    if gen.returncode != 0:
+        pytest.skip(
+            f"cannot create test key: {gen.stderr.decode(errors='replace')}"
+        )
+
+    source = (
+        "2026-01-01 open Assets:Cash\n"
+        "2026-01-01 open Equity:Open\n"
+        '2026-01-02 * "encrypted entry"\n'
+        "  Assets:Cash  1.00 USD\n"
+        "  Equity:Open  -1.00 USD\n"
+    )
+    ledger = tmp_path / "ledger.beancount.gpg"
+    enc = subprocess.run(
+        [  # noqa: S607
+            "gpg",
+            "--batch",
+            "--encrypt",
+            "--recipient",
+            "rustfava-test@example.invalid",
+            "--trust-model",
+            "always",
+            "--output",
+            str(ledger),
+        ],
+        input=source.encode(),
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    assert enc.returncode == 0, enc.stderr.decode(errors="replace")
+
+    old = os.environ.get("GNUPGHOME")
+    os.environ["GNUPGHOME"] = str(gnupg)
+    try:
+        entries, errors, _ = loader.load_uncached(str(ledger))
+    finally:
+        if old is None:
+            os.environ.pop("GNUPGHOME", None)
+        else:
+            os.environ["GNUPGHOME"] = old
+    assert not errors, [str(e) for e in errors]
+    assert entries, "encrypted ledger produced no entries"
+
+
+def test_host_decrypt_gpg_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """gpg not being runnable surfaces as an err result, not an exception."""
+
+    def boom(*_args: object, **_kwargs: object) -> object:
+        message = "gpg not found"
+        raise OSError(message)
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    result = _host_decrypt(None, b"data")
+    assert result.tag == "err"
+    assert "failed to run gpg" in str(result.payload)
+
+
+def test_host_decrypt_non_utf8(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Decrypted bytes that are not UTF-8 surface as an err result."""
+
+    class FakeProc:
+        returncode = 0
+        stdout = b"\xff\xfe\x00binary"
+        stderr = b""
+
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: FakeProc())
+    result = _host_decrypt(None, b"data")
+    assert result.tag == "err"
+    assert "not valid UTF-8" in str(result.payload)

--- a/tests/test_rustledger_component_engine.py
+++ b/tests/test_rustledger_component_engine.py
@@ -52,7 +52,7 @@ SRC = (
 
 
 def test_version(engine: RustledgerComponentEngine) -> None:
-    assert engine.version() == "3.1"
+    assert engine.version() == "3.2"
 
 
 def test_load_marshals_typed_directives(


### PR DESCRIPTION
Completes #218, which bumped `RUSTLEDGER_VERSION` to v0.19.0 but didn't adapt to the release's **breaking FFI change** (rustledger#1667, WIT 3.2.0). As of #218, a fresh install that downloads the v0.19.0 component **cannot instantiate it**:

```
component imports instance `rustledger:ledger/host@3.2.0`, but a matching
implementation was not found in the linker
```

v0.19.0 delegates decryption of encrypted ledgers to the host: the component imports `rustledger:ledger/host@3.2.0` with `decrypt: func(ciphertext: list<u8>) -> result<string, string>` and calls it on `.gpg`/`.asc` inputs.

## Changes
- **component engine**: `_WIT_VERSION` → `3.2.0`; the wasmtime linker now defines the host interface, implementing `decrypt` with the system `gpg --batch --decrypt` (keyring + gpg-agent) — mirroring rustledger's native loader semantics. Failures surface as the WIT `err` case, so hosts without usable keys still fail cleanly.
- **vendored component** refreshed to the v0.19.0 release asset (**sha256-verified**) — it was still v0.18.0.
- **tests**: encrypted-ledger suite rewritten for the new capability — adds an **end-to-end round-trip** (throwaway keyring → encrypt → load through the component → entries produced) plus direct err-branch coverage (gpg missing, non-UTF-8 plaintext); `api_version` assertion `3.1` → `3.2`.

## Net effect
**Encrypted ledgers now load end-to-end on the default component backend** — previously detect-only with a clean failure.

## Validation
`560 passed, 1 skipped` (pre-existing), **100% branch coverage maintained**; component smoke: instantiates, `api_version 3.2`, loads plaintext + encrypted ledgers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)