### PR TITLE
test(holdings): regression for the cost_date aliased ORDER BY (#190)

### DIFF
--- a/tests/test_holdings_query.py
+++ b/tests/test_holdings_query.py
@@ -1,0 +1,72 @@
+"""The Holdings report's query compiles and returns cost-dated lots.
+
+Regression coverage for https://github.com/rustledger/rustfava/issues/190 —
+the query orders by ``cost_date``, a raw column that is aliased in the SELECT
+(``cost_date as acquisition_date``). rustledger's compiler used to drop the
+hidden sort column for aliased raw columns and every Holdings render failed
+with ``column 'cost_date' not found`` (rustledger/rustledger#1627, fixed in
+rustledger/rustledger#1631, shipped in v0.17.0).
+
+The query below must stay in sync with
+``frontend/src/reports/holdings/index.ts``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from rustfava.core import RustfavaLedger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_HOLDINGS_QUERY = """
+SELECT
+  account,
+  units(sum(position)) as units,
+  cost_number as cost,
+  first(getprice(currency, cost_currency)) as price,
+  cost(sum(position)) as book_value,
+  value(sum(position)) as market_value,
+  safediv((abs(sum(number(value(position))))
+           - abs(sum(number(cost(position))))),
+          sum(number(cost(position)))) * 100 as unrealized_profit_pct,
+  cost_date as acquisition_date
+WHERE account_sortkey(account) ~ "^[01]"
+GROUP BY account, cost_date, currency, cost_currency, cost_number,
+         account_sortkey(account)
+ORDER BY account_sortkey(account), currency, cost_date
+""".strip()
+
+_LEDGER = """
+2020-01-01 open Assets:Bank:Checking      USD
+2020-01-01 open Assets:Brokerage          USD,AAPL,VTI
+2024-01-20 * "Brokerage" "Buy index fund"
+  Assets:Brokerage         10 VTI {450.00 USD, 2024-01-20}
+  Assets:Bank:Checking  -4500.00 USD
+2024-01-21 * "Brokerage" "Buy index fund"
+  Assets:Brokerage         20 VTI {400.00 USD, 2024-01-21}
+  Assets:Bank:Checking  -8000.00 USD
+"""
+
+
+def test_holdings_query_compiles_with_cost_dated_lots(tmp_path: Path) -> None:
+    """The exact repro from #190: two cost-dated lots of the same commodity."""
+    path = tmp_path / "holdings.beancount"
+    path.write_text(_LEDGER)
+    ledger = RustfavaLedger(str(path))
+
+    result = ledger.query_shell.execute_query_serialised(
+        ledger.all_entries, _HOLDINGS_QUERY
+    )
+
+    lots = [
+        row
+        for row in result.rows
+        if row[0] == "Assets:Brokerage" and row[1].get("VTI")
+    ]
+    units = sorted(lot[1]["VTI"] for lot in lots)
+    assert units == [Decimal(10), Decimal(20)], (
+        "expected the two VTI lots to survive the GROUP BY on cost_date"
+    )

--- a/tests/test_holdings_query.py
+++ b/tests/test_holdings_query.py
@@ -17,6 +17,8 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from rustfava.core import RustfavaLedger
+from rustfava.core.inventory import SimpleCounterInventory
+from rustfava.core.query import QueryResultTable
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -61,12 +63,16 @@ def test_holdings_query_compiles_with_cost_dated_lots(tmp_path: Path) -> None:
         ledger.all_entries, _HOLDINGS_QUERY
     )
 
-    lots = [
-        row
-        for row in result.rows
-        if row[0] == "Assets:Brokerage" and row[1].get("VTI")
-    ]
-    units = sorted(lot[1]["VTI"] for lot in lots)
-    assert units == [Decimal(10), Decimal(20)], (
+    assert isinstance(result, QueryResultTable)
+    units: list[Decimal] = []
+    for row in result.rows:
+        inventory = row[1]
+        if row[0] == "Assets:Brokerage" and isinstance(
+            inventory, SimpleCounterInventory
+        ):
+            vti = inventory.get("VTI")
+            if vti is not None:
+                units.append(vti)
+    assert sorted(units) == [Decimal(10), Decimal(20)], (
         "expected the two VTI lots to survive the GROUP BY on cost_date"
     )


### PR DESCRIPTION
Closes #190.

The Holdings report has been fixed on main since the v0.19.0 engine upgrade (#219): the root cause was rustledger dropping the hidden sort column for `ORDER BY <raw column aliased in SELECT>` (rustledger#1627 → fixed in rustledger#1631, shipped in v0.17.0). Verified with the issue's exact repro ledger: the frontend's exact Holdings query compiles and returns both cost-dated VTI lots (previously `column 'cost_date' not found` → HTTP 500).

This PR pins that behavior with a regression test — the repro ledger + the Holdings query (kept in sync with `frontend/src/reports/holdings/index.ts`), asserting compilation succeeds and both lots survive the `GROUP BY cost_date`.

Note for the reporter: the fix reaches released builds with the next rustfava release (1.30.13 predates the engine bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)