### PR TITLE
ci(flake-sources): fire on tag-triggered Desktop Release runs

### DIFF
--- a/.github/workflows/update-flake-sources.yml
+++ b/.github/workflows/update-flake-sources.yml
@@ -1,11 +1,14 @@
 name: Update Flake Sources
 
 on:
-  # Trigger after Desktop Release completes (which uploads the tarballs)
+  # Trigger after Desktop Release completes (which uploads the tarballs).
+  # NB: no `branches:` filter — for tag-triggered runs head_branch is the TAG
+  # (e.g. v1.31.0), so filtering to main silently excluded every release and
+  # this automation never fired (found during the v1.31.0 release). The
+  # job-level `if` below does the actual gating.
   workflow_run:
     workflows: ["Desktop Release"]
     types: [completed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       version:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,12 +32,10 @@ The tag triggers several workflows:
 
 Monitor at: https://github.com/rustledger/rustfava/actions
 
-### 3. Approve PyPI deployment
+### 3. PyPI deployment
 
-The PyPI environment requires manual approval:
-- Go to the running `build-publish.yml` workflow
-- Click "Review deployments"
-- Approve the `pypi` environment
+Publishes automatically when the `build-publish.yml` workflow reaches the
+`pypi` job — no manual approval is configured (verified during v1.31.0).
 
 ### 4. Publish the GitHub release
 
@@ -57,7 +55,9 @@ Or via GitHub UI: https://github.com/rustledger/rustfava/releases
 
 ### 5. Update Nix flake sources
 
-Publishing the release triggers `update-flake-sources.yml`, which:
+The `update-flake-sources.yml` workflow fires when a tag-triggered
+`Desktop Release` run completes (it can also be run manually via
+`gh workflow run update-flake-sources.yml -f version=vX.Y.Z`). It:
 1. Downloads release tarballs
 2. Computes SRI hashes
 3. Creates a PR updating `desktop-sources.json`
@@ -79,7 +79,8 @@ nix run github:rustledger/rustfava --refresh
 uv tool install rustfava --upgrade
 
 # Docker
-docker pull ghcr.io/rustledger/rustfava:v0.1.x
+# NB: the image tag has no "v" prefix
+docker pull ghcr.io/rustledger/rustfava:0.1.x
 ```
 
 ## Release Artifacts
@@ -97,7 +98,9 @@ docker pull ghcr.io/rustledger/rustfava:v0.1.x
 Check that `desktop-release.yml` completed successfully. The release job only runs on tags.
 
 ### Nix flake sources not updated
-The `update-flake-sources.yml` workflow only triggers on `release: published` events. Make sure the release is not still in draft.
+The `update-flake-sources.yml` workflow triggers when the tag's `Desktop
+Release` run completes successfully. If it didn't fire, dispatch it manually:
+`gh workflow run update-flake-sources.yml -f version=vX.Y.Z`.
 
 ### PyPI publish failed
 Check the workflow logs. Common issues:


### PR DESCRIPTION
Found during the v1.31.0 release: the `workflow_run` trigger filtered to `branches: [main]`, but a tag-triggered Desktop Release run carries the **tag** as `head_branch` (`v1.31.0`) — so the flake-sources automation has never fired for an actual release. The job-level `if` even expects `head_branch` to start with `v`, directly contradicting the trigger filter (every run it ever saw was a main-branch run, correctly skipped).

Fix: drop the `branches:` filter from the trigger — the job-level condition already does the real gating (success + `v*` head branch, or manual dispatch).

v1.31.0 itself was worked around via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)