### PR TITLE
Route-smoke suite + coverage burn-down (query.py, component_engine.py into the 100% gate)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,21 @@ jobs:
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
       - name: Install wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
+      - name: Provision rustledger component WASM
+        shell: bash
+        # The component is gitignored (downloaded lazily at runtime), so CI
+        # checkouts lack it and every component-gated test silently skipped
+        # (the availability gate is evaluated at import time, before the
+        # lazy download can happen). Provision the pinned release asset so
+        # the component suite actually runs — and coverage of
+        # component_engine.py (now inside the 100% gate) is complete.
+        run: |
+          TAG=$(grep -oE 'RUSTLEDGER_VERSION = "v[0-9.]+"' src/rustfava/rustledger/engine.py | grep -oE 'v[0-9.]+')
+          gh release download "$TAG" --repo rustledger/rustledger \
+            --pattern "rustledger-ffi-component-*.wasm" \
+            --output src/rustfava/rustledger/rustledger_ffi_component.wasm
+        env:
+          GH_TOKEN: ${{ github.token }}
       - run: touch src/rustfava/static/app.js
       - run: just test-py
 
@@ -68,6 +83,21 @@ jobs:
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
       - name: Install wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
+      - name: Provision rustledger component WASM
+        shell: bash
+        # The component is gitignored (downloaded lazily at runtime), so CI
+        # checkouts lack it and every component-gated test silently skipped
+        # (the availability gate is evaluated at import time, before the
+        # lazy download can happen). Provision the pinned release asset so
+        # the component suite actually runs — and coverage of
+        # component_engine.py (now inside the 100% gate) is complete.
+        run: |
+          TAG=$(grep -oE 'RUSTLEDGER_VERSION = "v[0-9.]+"' src/rustfava/rustledger/engine.py | grep -oE 'v[0-9.]+')
+          gh release download "$TAG" --repo rustledger/rustledger \
+            --pattern "rustledger-ffi-component-*.wasm" \
+            --output src/rustfava/rustledger/rustledger_ffi_component.wasm
+        env:
+          GH_TOKEN: ${{ github.token }}
       - run: touch src/rustfava/static/app.js
       - run: just test-py-typeguard
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,8 +193,15 @@ omit = [
     "src/rustfava/_version.py",
     "src/rustfava/beans/types.py",
     "src/rustfava/ext/auto_commit.py",
-    # Rustledger integration - new code with many error handling paths
-    "src/rustfava/rustledger/*",
+    # Rustledger integration - new code with many error handling paths.
+    # Being burned down file by file: query.py and component_engine.py are
+    # now measured; the rest remain exempt.
+    "src/rustfava/rustledger/__init__.py",
+    "src/rustfava/rustledger/backend.py",
+    "src/rustfava/rustledger/engine.py",
+    "src/rustfava/rustledger/loader.py",
+    "src/rustfava/rustledger/options.py",
+    "src/rustfava/rustledger/types.py",
     "src/rustfava/beans/create.py",
     "src/rustfava/beans/str.py",
     "src/rustfava/beans/abc.py",

--- a/src/rustfava/rustledger/query.py
+++ b/src/rustfava/rustledger/query.py
@@ -113,6 +113,32 @@ def _datatype_from_string(datatype: str) -> type:
     return _DATATYPE_MAP.get(datatype, object)
 
 
+def _positions_to_currency_map(value: dict[str, Any]) -> dict[str, Decimal]:
+    """Flatten an Inventory payload to a units-summed ``{currency: Decimal}``.
+
+    Inventory comes as ``{"positions": [{"units": {"number": ..., "currency":
+    ...}}]}``. The FFI payload carries units only -- no per-position cost
+    basis -- so this form is the complete information available for an
+    inventory column. Cost basis / market value are exposed separately via
+    the COST()/VALUE() BQL functions. Preserving cost lots here would require
+    the engine to emit cost per position first; see rustledger/rustfava#155.
+
+    Sums across lots: an inventory may hold several positions of the same
+    currency at different cost bases; flattening must accumulate, not
+    overwrite, or all but one lot is lost.
+    """
+    result: dict[str, Decimal] = {}
+    for pos in value.get("positions", []):
+        units = pos.get("units", {})
+        currency = units.get("currency", "")
+        number = units.get("number", "0")
+        if currency:
+            result[currency] = result.get(currency, Decimal(0)) + Decimal(
+                number
+            )
+    return result
+
+
 def _convert_row_value(value: Any, column: dict[str, str]) -> Any:
     """Convert a row value based on column type."""
     if value is None:
@@ -123,32 +149,21 @@ def _convert_row_value(value: Any, column: dict[str, str]) -> Any:
     if datatype == "Decimal" and isinstance(value, str):
         return Decimal(value)
     if datatype == "Amount" and isinstance(value, dict):
-        return RLAmount.from_json(value)
+        # The engine sometimes declares Amount but ships an Inventory-shaped
+        # payload ({"positions": [...]}) — e.g. value(sum(position)) when the
+        # result is an inventory (rustledger#1701). Shape-sniff instead of
+        # trusting the declared type: crashing row marshalling turns one odd
+        # cell into an HTTP 500 for the whole query (found by the route-smoke
+        # suite on long-example).
+        return (
+            _positions_to_currency_map(value)
+            if "positions" in value and "number" not in value
+            else RLAmount.from_json(value)
+        )
     if datatype == "set" and isinstance(value, list):
         return frozenset(value)
     if datatype == "Inventory" and isinstance(value, dict):
-        # Inventory comes as {"positions": [{"units": {"number": "...", "currency": "..."}}]}
-        # The FFI payload carries units only -- no per-position cost basis -- so
-        # this units-summed {currency: Decimal} form is the complete information
-        # available for an inventory column. Cost basis / market value are
-        # exposed separately via the COST()/VALUE() BQL functions (which return
-        # scalar amounts). Preserving cost lots here would require the engine to
-        # emit cost per position first; see rustledger/rustfava#155.
-        positions = value.get("positions", [])
-        result: dict[str, Decimal] = {}
-        for pos in positions:
-            units = pos.get("units", {})
-            currency = units.get("currency", "")
-            number = units.get("number", "0")
-            if currency:
-                # Sum across lots: an inventory may hold several positions of
-                # the same currency at different cost bases (now that the
-                # serializer preserves cost). Flattening to {currency: number}
-                # must accumulate, not overwrite, or all but one lot is lost.
-                result[currency] = result.get(currency, Decimal(0)) + Decimal(
-                    number
-                )
-        return result
+        return _positions_to_currency_map(value)
 
     return value
 
@@ -166,9 +181,9 @@ class CompilationError(RLQueryError):
 
 
 def connect(
-    connection_string: str,
+    connection_string: str,  # noqa: ARG001 - beanquery-interface compat
     entries: Sequence[Directive],
-    errors: Sequence[BeancountError],
+    errors: Sequence[BeancountError],  # noqa: ARG001 - ignored, per docstring
     options: BeancountOptions,
 ) -> RLConnection:
     """Create a connection for running queries.
@@ -209,8 +224,8 @@ class RLConnection:
     def set_source(self, source: str) -> None:
         """Set the source for queries.
 
-        Since rustledger queries operate on source text (not serialized entries),
-        we need the original source.
+        Since rustledger queries operate on source text (not serialized
+        entries), we need the original source.
         """
         self._source = source
 
@@ -237,7 +252,8 @@ class RLConnection:
             )
         else:
             if self._source is None:
-                # JSON-RPC engine queries source text; re-serialize the entries.
+                # JSON-RPC engine queries source text; re-serialize
+                # the entries.
                 self._source = _entries_to_source(self._entries)
             result = self._engine.query(self._source, query_string)
 

--- a/tests/test_rustledger_component_marshal.py
+++ b/tests/test_rustledger_component_marshal.py
@@ -1,0 +1,412 @@
+"""Unit coverage for the component engine's marshalling helpers.
+
+Part of the coverage burn-down that reclaimed
+``src/rustfava/rustledger/component_engine.py`` into the 100% gate: these
+exercise the pure helpers and error/edge branches that the integration tests
+(differential corpus, smoke suite) do not reach.
+"""
+
+from __future__ import annotations
+
+import urllib.request
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+from wasmtime.component import Bool
+from wasmtime.component import ListType
+from wasmtime.component import OptionType
+from wasmtime.component import Record
+from wasmtime.component import RecordType
+from wasmtime.component import ResultType
+from wasmtime.component import String
+from wasmtime.component import TupleType
+from wasmtime.component import Variant
+from wasmtime.component import VariantType
+
+import rustfava.rustledger.component_engine as ce
+from rustfava.rustledger.component_engine import _default_wasm_path
+from rustfava.rustledger.component_engine import _download_component_wasm
+from rustfava.rustledger.component_engine import _drop_none
+from rustfava.rustledger.component_engine import _finalize_query_result
+from rustfava.rustledger.component_engine import _meta_value_json
+from rustfava.rustledger.component_engine import _unwrap_query_value
+from rustfava.rustledger.component_engine import RustledgerComponentEngine
+from rustfava.rustledger.constants import Missing
+from rustfava.rustledger.engine import RustledgerError
+
+
+def test_wasm_path_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUSTLEDGER_COMPONENT_WASM", "/somewhere/custom.wasm")
+    assert _default_wasm_path() == Path("/somewhere/custom.wasm")
+
+
+def test_download_component_writes_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_retrieve(_url: str, path: str) -> None:
+        Path(path).write_bytes(b"wasm")
+
+    monkeypatch.setattr(urllib.request, "urlretrieve", fake_retrieve)
+    target = tmp_path / "nested" / "component.wasm"
+    _download_component_wasm(target)
+    assert target.read_bytes() == b"wasm"
+
+
+def test_download_component_failure_leaves_no_partial_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_retrieve(_url: str, path: str) -> None:
+        Path(path).write_bytes(b"partial")
+        message = "network down"
+        raise OSError(message)
+
+    monkeypatch.setattr(urllib.request, "urlretrieve", fake_retrieve)
+    target = tmp_path / "component.wasm"
+    _download_component_wasm(target)
+    assert not target.exists()
+
+
+def test_unwrap_query_value_kinds() -> None:
+    assert _unwrap_query_value("plain") == "plain"
+    assert _unwrap_query_value({"no-type": 1}) == {"no-type": 1}
+    assert _unwrap_query_value({"type": "null"}) is None
+
+
+def test_drop_none_recurses_lists_and_dicts() -> None:
+    assert _drop_none([{"a": 1, "b": None}, None]) == [{"a": 1}, None]
+
+
+def test_finalize_query_result_without_rows() -> None:
+    assert _finalize_query_result({"errors": []}) == {"errors": []}
+
+
+def test_meta_value_json_scalars() -> None:
+    assert _meta_value_json(Decimal("1.5")) == {
+        "type": "number",
+        "value": "1.5",
+    }
+    assert _meta_value_json(value=True) == {"type": "boolean", "value": True}
+    assert _meta_value_json(None) == {"type": "null"}
+    assert _meta_value_json("txt") == {"type": "text", "value": "txt"}
+    assert _meta_value_json({"number": "2", "currency": "USD"}) == {
+        "type": "amount",
+        "number": "2",
+        "currency": "USD",
+    }
+    assert _meta_value_json({"odd": "shape"}) == {"type": "null"}
+
+
+@pytest.fixture(scope="module")
+def engine() -> RustledgerComponentEngine:
+    return RustledgerComponentEngine()
+
+
+def test_validate_and_format_entries(
+    engine: RustledgerComponentEngine,
+) -> None:
+    source = '2020-01-01 open Assets:Cash\n2020-01-02 *  "x"  ""\n'
+    result = engine.validate(source)
+    assert "valid" in result
+    formatted = engine.format_entries("2020-01-01  open   Assets:Cash\n")
+    assert "Assets:Cash" in formatted
+
+
+def _builder_func_type(engine: RustledgerComponentEngine, name: str) -> Any:
+    """Fetch a real wasmtime function type from the component's builder."""
+    fidx = engine._component.get_export_index(name, engine._iface(ce._BUILDER))
+    func = engine._inst.get_func(engine._store, fidx)
+    return func.type(engine._store)
+
+
+def test_marshal_result_err_raises(engine: RustledgerComponentEngine) -> None:
+    """result<ok, err> lifting: err surfaces as RustledgerError, ok unwraps.
+
+    Uses the real ResultType from the component's builder ``create`` (its
+    ok is the directive variant; a None payload short-circuits marshalling,
+    so no Record needs fabricating).
+    """
+    result_type = _builder_func_type(engine, "create").result
+    with pytest.raises(RustledgerError, match="boom"):
+        ce._marshal(Variant("err", "boom"), result_type)
+    case_tag = next(iter(dict(result_type.ok.cases)))
+    ok_value = Variant("ok", Variant(case_tag, None))
+    assert ce._marshal(ok_value, result_type) == {"type": ce._snake(case_tag)}
+
+
+def test_cost_number_from_json_shapes() -> None:
+    v = ce._cost_number_from_json(
+        {"kind": "per_unit_from_total", "per_unit": "2", "total": "10"}
+    )
+    assert (v.tag, v.payload) == ("per-unit-from-total", ("2", "10"))
+    v = ce._cost_number_from_json({"type": "total", "value": "10"})
+    assert (v.tag, v.payload) == ("total", "10")
+    v = ce._cost_number_from_json("3.5")
+    assert (v.tag, v.payload) == ("per-unit", "3.5")
+
+
+def test_query_entries_roundtrips_meta_scalars(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """Entries with number/bool/null meta survive the typed input marshalling
+    (exercises the meta-value tagging branches on the way into the
+    component)."""
+    loaded = engine.load(
+        "2020-01-01 open Assets:Cash\n"
+        '2020-01-02 * "n"\n'
+        "  n: 42\n"
+        "  b: TRUE\n"
+        '  s: "text"\n'
+        "  Assets:Cash  1.00 USD\n"
+        "2020-01-03 open Equity:Open\n"
+    )
+    result = engine.query_entries(loaded["entries"], "SELECT account")
+    assert result.get("rows"), result
+
+
+def test_unwrap_query_value_position_and_json() -> None:
+    pos = {"type": "position", "units": {"number": "1", "currency": "X"}}
+    assert _unwrap_query_value(pos) == {
+        "units": {"currency": "X", "number": "1"}
+    }
+    assert _unwrap_query_value({"type": "json", "value": "[1, 2]"}) == [1, 2]
+
+
+def test_marshal_untyped_fallbacks() -> None:
+    rec = Record()
+    rec.some_field = 1  # type: ignore[attr-defined]
+    assert ce._marshal(rec, object()) == {"some_field": 1}
+    assert ce._marshal(Variant("a-tag", 2), object()) == {
+        "type": "a_tag",
+        "value": 2,
+    }
+    assert ce._marshal("bare", object()) == "bare"
+
+
+def _harvest_types(vtype: Any, found: dict[str, Any]) -> None:
+    """Walk a wasmtime type tree collecting one instance per type class."""
+    found.setdefault(type(vtype).__name__, vtype)
+    if isinstance(vtype, RecordType):
+        for _name, field in vtype.fields:
+            _harvest_types(field, found)
+    elif isinstance(vtype, VariantType):
+        for _name, case in vtype.cases:
+            if case is not None:
+                _harvest_types(case, found)
+    elif isinstance(vtype, (ListType, OptionType)):
+        _harvest_types(
+            vtype.element if isinstance(vtype, ListType) else vtype.payload,
+            found,
+        )
+    elif isinstance(vtype, TupleType):
+        for element in vtype.elements:
+            _harvest_types(element, found)
+    elif isinstance(vtype, ResultType) and vtype.ok is not None:
+        _harvest_types(vtype.ok, found)
+
+
+@pytest.fixture(scope="module")
+def component_types(
+    engine: RustledgerComponentEngine,
+) -> dict[str, Any]:
+    found: dict[str, Any] = {}
+    ftype = _builder_func_type(engine, "create")
+    for _name, param in ftype.params:
+        _harvest_types(param, found)
+    _harvest_types(ftype.result, found)
+    return found
+
+
+def test_default_for_every_type_class(
+    component_types: dict[str, Any],
+) -> None:
+    expected: Any
+    for name, expected in [
+        ("OptionType", None),
+        ("ListType", []),
+        ("String", ""),
+        ("Bool", False),
+    ]:
+        vtype = component_types.get(name)
+        if vtype is None:
+            pytest.skip(f"component exposes no {name}")
+        got = ce._default_for(vtype)
+        assert got == expected, name
+        assert isinstance(vtype, (String, Bool)) or got == expected
+    record = component_types.get("RecordType")
+    assert record is not None
+    assert isinstance(ce._default_for(record), object)
+    # numeric fallback
+    numeric = component_types.get("U32") or component_types.get("S64")
+    if numeric is not None:
+        assert ce._default_for(numeric) == 0
+
+
+def test_clamp_roundtrip_with_rich_shapes(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """Entries with total-cost lots, posting metadata, and typed custom
+    values survive the unmarshal -> component -> marshal round trip
+    (covers the variant/pair-list edge branches on both directions)."""
+    loaded = engine.load(
+        "2020-01-01 open Assets:Cash\n"
+        "2020-01-01 open Assets:Brokerage\n"
+        '2020-01-02 * "buy with total cost"\n'
+        "  Assets:Brokerage  2 VTI {5.00 # 10.00 USD}\n"
+        '    lot-note: "kept"\n'
+        "  Assets:Cash  -10.00 USD\n"
+        '2020-01-03 custom "budget" 42 TRUE "text"\n'
+    )
+    # No assertion on load errors: the engine's `#`-cost balance weighing is
+    # currently wrong in both directions (rustledger#1700); this test targets
+    # marshalling, and the posting carries the correct per-unit-from-total
+    # cost shape either way.
+    entries = loaded["entries"]
+    txn = next(e for e in entries if e.get("type") == "transaction")
+    cost_in = txn["postings"][0]["cost"]["number"]
+    assert cost_in["kind"] == "per_unit_from_total"
+    result = engine.clamp_entries(entries, "2020-01-01", "2021-01-01")
+    out = next(e for e in result["entries"] if e.get("type") == "transaction")
+    cost_out = out["postings"][0]["cost"]["number"]
+    assert cost_out == {
+        "kind": "per_unit_from_total",
+        "per_unit": "5.00",
+        "total": "10.00",
+    }
+
+
+def test_unwrap_query_value_interval_fallback() -> None:
+    cell = {"type": "interval", "begin": "2020-01-01", "end": "2020-02-01"}
+    assert _unwrap_query_value(cell) == {
+        "begin": "2020-01-01",
+        "end": "2020-02-01",
+    }
+
+
+def test_rewrite_guest_paths_edge_shapes() -> None:
+    result: dict[str, Any] = {
+        "entries": [
+            {"meta": {"filename": "/work/main.beancount"}},
+            {"meta": {"lineno": 1}},  # no filename
+            {"meta": None},  # non-dict meta
+        ],
+        "includes": [
+            {"path": "/work/inc.beancount"},
+            {"other": "shape"},  # no path
+        ],
+    }
+    RustledgerComponentEngine._rewrite_guest_paths(result, Path("/host"))
+    assert result["entries"][0]["meta"]["filename"] == "/host/main.beancount"
+    assert result["includes"][0]["path"] == "/host/inc.beancount"
+    assert result["includes"][1] == {"other": "shape"}
+
+
+def test_clamp_accepts_mutated_edge_json(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """Edge shapes a host may feed back into clamp: typed custom values
+    (number/null), an already-kebab cost kind, and null meta values —
+    exercising the input-unmarshal tolerance branches with real types."""
+    loaded = engine.load(
+        "2020-01-01 open Assets:Cash\n"
+        "2020-01-01 open Assets:B\n"
+        '2020-01-02 * "x"\n'
+        "  Assets:B  2 VTI {5.00 USD}\n"
+        "  Assets:Cash  -10.00 USD\n"
+        '2020-01-03 custom "budget" "seed"\n'
+    )
+    entries = loaded["entries"]
+    txn = next(e for e in entries if e.get("type") == "transaction")
+    # already-kebab cost kind (the tag-tolerance branch)
+    txn["postings"][0]["cost"]["number"] = {
+        "kind": "per-unit",
+        "value": "5.00",
+    }
+    # meta with a null value (meta-value variant, payload-less case)
+    txn["meta"]["note"] = None
+    custom = next(e for e in entries if e.get("type") == "custom")
+    # typed custom values: number and null
+    custom["values"] = [
+        {"type": "number", "value": 42},
+        {"type": "null", "value": None},
+    ]
+    result = engine.clamp_entries(entries, "2020-01-01", "2021-01-01")
+    assert result["entries"]
+
+
+def _find_meta_pair_list(vtype: Any) -> Any | None:
+    """Locate the ``list<tuple<string, meta-value>>`` type in a type tree."""
+    if ce._is_pair_list(vtype) and ce._is_meta_value(
+        ce._pair_value_type(vtype)
+    ):
+        return vtype
+    if isinstance(vtype, RecordType):
+        children = [field for _n, field in vtype.fields]
+    elif isinstance(vtype, VariantType):
+        children = [case for _n, case in vtype.cases if case is not None]
+    elif isinstance(vtype, ListType):
+        children = [vtype.element]
+    elif isinstance(vtype, OptionType):
+        children = [vtype.payload]
+    else:
+        children = []
+    for child in children:
+        found = _find_meta_pair_list(child)
+        if found is not None:
+            return found
+    return None
+
+
+@pytest.fixture(scope="module")
+def meta_pair_list(engine: RustledgerComponentEngine) -> Any:
+    ftype = _builder_func_type(engine, "create")
+    for _name, param in ftype.params:
+        found = _find_meta_pair_list(param)
+        if found is not None:
+            return found
+    pytest.skip("component exposes no meta pair-list type")
+
+
+def test_unmarshal_meta_dict_into_pair_list(meta_pair_list: Any) -> None:
+    """A dict-shaped meta map re-tags scalars as meta-value variants."""
+    pairs = ce._unmarshal({"note": "hi", "n": Decimal(2)}, meta_pair_list)
+    assert [(k, v.tag) for k, v in pairs] == [
+        ("note", "text"),
+        ("n", "number"),
+    ]
+
+
+def test_unmarshal_non_meta_pair_list(
+    meta_pair_list: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A string-keyed map whose values are NOT meta-values unmarshals each
+    value by its actual type (the plain pair-list branch)."""
+    monkeypatch.setattr(ce, "_is_meta_value", lambda _vtype: False)
+    pairs = ce._unmarshal(
+        {"note": {"type": "text", "value": "hi"}}, meta_pair_list
+    )
+    assert [(k, v.tag) for k, v in pairs] == [("note", "text")]
+
+
+def test_unmarshal_unknown_variant_tag_raises(meta_pair_list: Any) -> None:
+    """An unknown variant tag survives the kebab-tolerance step and then
+    fails loudly on case lookup."""
+    vtype = ce._pair_value_type(meta_pair_list)
+    with pytest.raises(KeyError):
+        ce._unmarshal({"type": "no_such_case"}, vtype)
+
+
+def test_unmarshal_pair_list_as_list_of_tuples(meta_pair_list: Any) -> None:
+    """A pair list arriving as an actual list of ``[key, value]`` pairs
+    unmarshals each pair through the tuple branch."""
+    pairs = ce._unmarshal(
+        [["note", {"type": "text", "value": "hi"}]], meta_pair_list
+    )
+    assert [(k, v.tag) for k, v in pairs] == [("note", "text")]
+
+
+def test_missing_sentinel_is_falsy_singleton() -> None:
+    assert Missing() is Missing()
+    assert repr(Missing()) == "MISSING"
+    assert not Missing()

--- a/tests/test_rustledger_component_marshal.py
+++ b/tests/test_rustledger_component_marshal.py
@@ -297,8 +297,14 @@ def test_rewrite_guest_paths_edge_shapes() -> None:
         ],
     }
     RustledgerComponentEngine._rewrite_guest_paths(result, Path("/host"))
-    assert result["entries"][0]["meta"]["filename"] == "/host/main.beancount"
-    assert result["includes"][0]["path"] == "/host/inc.beancount"
+    # expected paths via the same Path arithmetic the code uses, so the
+    # assertion holds on Windows (backslash separators) too
+    assert result["entries"][0]["meta"]["filename"] == str(
+        Path("/host") / "main.beancount"
+    )
+    assert result["includes"][0]["path"] == str(
+        Path("/host") / "inc.beancount"
+    )
     assert result["includes"][1] == {"other": "shape"}
 
 

--- a/tests/test_rustledger_query.py
+++ b/tests/test_rustledger_query.py
@@ -13,9 +13,15 @@ from decimal import Decimal
 from typing import cast
 from typing import TYPE_CHECKING
 
+import pytest
+
 from rustfava.beans import create
 from rustfava.rustledger.query import _convert_row_value
 from rustfava.rustledger.query import _entries_to_source
+from rustfava.rustledger.query import CompilationError
+from rustfava.rustledger.query import connect
+from rustfava.rustledger.query import ParseError
+from rustfava.rustledger.query import RLCursor
 from rustfava.rustledger.types import RLCustom
 from rustfava.rustledger.types import RLCustomValue
 from rustfava.rustledger.types import RLOpen
@@ -24,9 +30,13 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from rustfava.beans.abc import Directive
+    from rustfava.beans.types import BeancountOptions
+    from rustfava.rustledger.query import RLConnection
 
 
-def test_entries_to_source_preserves_transaction_tags_links_and_metadata() -> None:
+def test_entries_to_source_preserves_transaction_tags_links_and_metadata() -> (
+    None
+):
     postings = [
         create.posting(
             "Assets:US:Bank",
@@ -71,7 +81,9 @@ def test_entries_to_source_preserves_cost_basis() -> None:
         create.posting(
             "Assets:US:Brokerage",
             "10 AAPL",
-            cost=create.cost(Decimal("170.50"), "USD", datetime.date(2024, 3, 20)),
+            cost=create.cost(
+                Decimal("170.50"), "USD", datetime.date(2024, 3, 20)
+            ),
         ),
         create.posting("Assets:US:Bank", "-1705.00 USD"),
     ]
@@ -114,7 +126,8 @@ def test_entries_to_source_preserves_open_booking_method() -> None:
         booking="STRICT",
     )
 
-    # rustledger ``RL*`` directives are a parallel hierarchy to ``abc.Directive``
+    # rustledger ``RL*`` directives are a parallel hierarchy to
+    # ``abc.Directive``
     # that ``_entries_to_source``/``to_string`` accept via singledispatch
     # duck-typing; cast to satisfy the static signature.
     source = _entries_to_source(cast("Sequence[Directive]", [opn]))
@@ -130,7 +143,10 @@ def test_entries_to_source_skips_fava_custom_directives() -> None:
         meta={},
         date=datetime.date(2024, 1, 1),
         type="fava-option",
-        values=(RLCustomValue("title", dtype=str), RLCustomValue("Test", dtype=str)),
+        values=(
+            RLCustomValue("title", dtype=str),
+            RLCustomValue("Test", dtype=str),
+        ),
     )
     other_custom = RLCustom(
         meta={},
@@ -165,7 +181,7 @@ def test_inventory_sums_same_currency_cost_lots() -> None:
         ]
     }
 
-    assert _convert_row_value(value, _INVENTORY_COL) == {"ITOT": Decimal("5")}
+    assert _convert_row_value(value, _INVENTORY_COL) == {"ITOT": Decimal(5)}
 
 
 def test_inventory_mixed_currencies_and_lots() -> None:
@@ -178,6 +194,155 @@ def test_inventory_mixed_currencies_and_lots() -> None:
     }
 
     assert _convert_row_value(value, _INVENTORY_COL) == {
-        "ITOT": Decimal("5"),
+        "ITOT": Decimal(5),
         "USD": Decimal("100.00"),
     }
+
+
+# -- cursor / conversion / connection unit coverage ---------------------------
+
+_AMOUNT_COL = {"name": "market_value", "datatype": "Amount"}
+
+
+def test_amount_column_with_inventory_shaped_payload() -> None:
+    """The engine sometimes declares Amount but ships an Inventory payload
+    (rustledger#1701, found by the route-smoke suite): marshalling must
+    flatten it rather than crash the whole query with a KeyError."""
+    value = {"positions": [{"units": {"currency": "USD", "number": "0"}}]}
+    assert _convert_row_value(value, _AMOUNT_COL) == {"USD": Decimal(0)}
+
+
+def test_convert_row_value_scalars_and_fallbacks() -> None:
+    assert _convert_row_value(None, _AMOUNT_COL) is None
+    decimal_col = {"name": "n", "datatype": "Decimal"}
+    assert _convert_row_value("3.14", decimal_col) == Decimal("3.14")
+    set_col = {"name": "tags", "datatype": "set"}
+    assert _convert_row_value(["a", "b"], set_col) == frozenset({"a", "b"})
+    unknown_col = {"name": "x", "datatype": "something-new"}
+    assert _convert_row_value("as-is", unknown_col) == "as-is"
+
+
+def test_cursor_description_fetch_and_unpack() -> None:
+    cursor = RLCursor(
+        columns=[
+            {"name": "account", "datatype": "str"},
+            {"name": "total", "datatype": "Decimal"},
+        ],
+        rows=[["Assets:Cash", "1.00"], ["Equity:Open", "-1.00"]],
+    )
+    name, datatype = cursor.description[1]
+    assert (name, datatype) == ("total", Decimal)
+    assert cursor.fetchone() == ("Assets:Cash", Decimal("1.00"))
+    assert cursor.fetchone() == ("Equity:Open", Decimal("-1.00"))
+    assert cursor.fetchone() is None
+    assert cursor.fetchall() == []
+
+
+class _ComponentStyleEngine:
+    """Engine stub exposing the component's ``query_entries``."""
+
+    def __init__(self, result: dict[str, object]) -> None:
+        self.result = result
+        self.queries: list[str] = []
+
+    def query_entries(
+        self, _directives_json: str, query: str
+    ) -> dict[str, object]:
+        self.queries.append(query)
+        return self.result
+
+
+class _LegacyStyleEngine:
+    """Engine stub with only the legacy source-text ``query``."""
+
+    def __init__(self, result: dict[str, object]) -> None:
+        self.result = result
+        self.sources: list[str] = []
+
+    def query(self, source: str, _query: str) -> dict[str, object]:
+        self.sources.append(source)
+        return self.result
+
+
+def _connection(engine: object) -> RLConnection:
+    options = cast("BeancountOptions", {})
+    conn = connect("beancount:", [], [], options)
+    conn._engine = engine
+    return conn
+
+
+def test_execute_via_component_engine() -> None:
+    engine = _ComponentStyleEngine(
+        {"columns": [{"name": "account", "datatype": "str"}], "rows": [["A"]]}
+    )
+    cursor = _connection(engine).execute("SELECT account")
+    assert cursor.fetchall() == [("A",)]
+    assert engine.queries == ["SELECT account"]
+
+
+def test_execute_via_legacy_engine_serialises_entries_once() -> None:
+    engine = _LegacyStyleEngine({"columns": [], "rows": []})
+    conn = _connection(engine)
+    conn.execute("SELECT account")
+    conn.execute("SELECT account")
+    assert engine.sources == ["", ""]  # no entries -> empty source, reused
+
+
+def test_execute_via_legacy_engine_honours_set_source() -> None:
+    engine = _LegacyStyleEngine({"columns": [], "rows": []})
+    conn = _connection(engine)
+    conn.set_source("2020-01-01 open Assets:Cash\n")
+    conn.execute("SELECT account")
+    assert engine.sources == ["2020-01-01 open Assets:Cash\n"]
+
+
+def test_execute_raises_parse_and_compilation_errors() -> None:
+    parse_engine = _ComponentStyleEngine(
+        {"errors": [{"message": "cannot parse query"}]}
+    )
+    with pytest.raises(ParseError):
+        _connection(parse_engine).execute("SELEKT")
+    compile_engine = _ComponentStyleEngine(
+        {"errors": [{"message": "column 'x' not found"}]}
+    )
+    with pytest.raises(CompilationError):
+        _connection(compile_engine).execute("SELECT x")
+    empty_message_engine = _ComponentStyleEngine({"errors": [{}]})
+    with pytest.raises(CompilationError, match="Unknown error"):
+        _connection(empty_message_engine).execute("SELECT x")
+
+
+def test_cursor_is_iterable() -> None:
+    cursor = RLCursor(
+        columns=[{"name": "account", "datatype": "str"}], rows=[["A"], ["B"]]
+    )
+    assert list(cursor) == [("A",), ("B",)]
+
+
+def test_inventory_position_without_currency_is_skipped() -> None:
+    value = {
+        "positions": [
+            {"units": {"number": "1"}},
+            {"units": {"currency": "USD", "number": "2"}},
+        ]
+    }
+    assert _convert_row_value(value, _INVENTORY_COL) == {"USD": Decimal(2)}
+
+
+def test_entries_to_source_skips_entries_that_render_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "rustfava.rustledger.query.to_string", lambda _entry: ""
+    )
+    entry = create.transaction(
+        meta={},
+        date=datetime.date(2020, 1, 1),
+        flag="*",
+        payee=None,
+        narration="x",
+        tags=frozenset(),
+        links=frozenset(),
+        postings=[],
+    )
+    assert _entries_to_source([entry]) == ""

--- a/tests/test_smoke_routes.py
+++ b/tests/test_smoke_routes.py
@@ -1,0 +1,199 @@
+"""Kitchen-sink smoke: every page and data source works for every ledger.
+
+Motivated by #190 and #191 — failures that any real user hit within minutes
+(the Holdings report 500'd for every ledger with cost-dated lots; the Help
+page 500'd on every packaged install) but that no test exercised. Three
+layers:
+
+1. every server-rendered route and client-report shell returns 200,
+2. every no-argument JSON API endpoint returns 200,
+3. every BQL query embedded in the frontend report sources is executed via
+   ``/api/query`` — the queries are extracted from ``frontend/src/reports``
+   at test time, so a frontend query change cannot silently drift out of
+   test coverage.
+
+All layers run against every ledger in the corpus ``app`` fixture.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from rustfava.application import CLIENT_SIDE_REPORTS
+from rustfava.help import HELP_PAGES
+
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
+
+# Ledgers from the corpus `app` fixture (see tests/conftest.py). The errors
+# and invalid-unicode ledgers are included deliberately: pages must degrade,
+# not crash, on ledgers with load errors.
+# NB: slugs derive from each ledger's `option "title"` when set — the
+# extension example titles itself "Extension Report" -> slug extension-report.
+LEDGER_SLUGS = [
+    "long-example",
+    "edit-example",
+    "example",
+    "extension-report",
+    "import",
+    "query-example",
+    "errors",
+    "off-by-one",
+    "invalid-unicode",
+]
+
+HOLDINGS_AGGREGATION_KEYS = ["account", "currency", "cost_currency"]
+
+# JSON API endpoints that take no parameters (parameterized endpoints like
+# context/source_slice need entry hashes and are covered elsewhere).
+API_ENDPOINTS = [
+    "changed",
+    "commodities",
+    "documents",
+    "events",
+    "imports",
+    "journal",
+    "narrations",
+    "options",
+    "income_statement",
+    "balance_sheet",
+    "trial_balance",
+]
+
+_FRONTEND_REPORTS = (
+    Path(__file__).parent.parent / "frontend" / "src" / "reports"
+)
+
+# Engine shortfalls this suite found on first run, tracked upstream: typed
+# scalar functions (only, abs, ...) type-error on NULL instead of propagating
+# it like beanquery — https://github.com/rustledger/rustledger/issues/1699.
+# Matched against the error BODY so a query is only excused for the known
+# engine gap on the ledgers that trigger it, and stays fully tested
+# everywhere else. Remove entries when the engine fix ships.
+KNOWN_ENGINE_GAPS = [
+    "ONLY: first argument must be a currency string",
+    "ABS expects a number",
+]
+
+
+def _known_engine_gap(body: str) -> bool:
+    return any(marker in body for marker in KNOWN_ENGINE_GAPS)
+
+
+def _frontend_queries() -> list[str]:
+    """Extract every BQL query string embedded in the frontend reports.
+
+    Matches template literals and plain string literals containing a SELECT.
+    Extraction happens at test time so the tested queries are always the
+    shipped ones (#190 regressed exactly here: a query the frontend ran on
+    every Holdings render that nothing on the Python side ever executed).
+    """
+    queries: list[str] = []
+    for source in sorted(_FRONTEND_REPORTS.glob("*/index.ts")):
+        text = source.read_text()
+        candidates = re.findall(r"`([^`]+)`", text, flags=re.DOTALL)
+        candidates += re.findall(r'"((?:[^"\\]|\\.)+)"', text)
+        # Only strings that ARE a query (anchored SELECT): plain substring
+        # matching also catches interstitial code when a file contains an odd
+        # number of backticks before the query block.
+        queries += [
+            c.strip() for c in candidates if c.strip().startswith("SELECT")
+        ]
+    return queries
+
+
+def test_frontend_query_extraction_finds_the_known_queries() -> None:
+    """Guard the extractor itself: the Holdings + statistics queries exist."""
+    queries = _frontend_queries()
+    assert len(queries) >= 5, queries
+    assert any("cost_date" in q for q in queries), (
+        "the Holdings acquisition-date query (#190) was not extracted"
+    )
+
+
+@pytest.mark.parametrize("ledger", LEDGER_SLUGS)
+def test_all_pages_render(test_client: FlaskClient, ledger: str) -> None:
+    """Layer 1: every page shell and server-rendered page returns 200."""
+    index = test_client.get(f"/{ledger}/")
+    assert index.status_code == 302, (
+        f"GET /{ledger}/ -> {index.status_code} (expected redirect to the "
+        "default report)"
+    )
+    urls = [f"/{ledger}/{report}/" for report in CLIENT_SIDE_REPORTS]
+    urls += [
+        f"/{ledger}/holdings/by_{key}/" for key in HOLDINGS_AGGREGATION_KEYS
+    ]
+    urls += [f"/{ledger}/account/Assets/"]
+    urls += [f"/{ledger}/help/"]
+    urls += [
+        # _index's canonical URL is /help/ (covered above); a direct hit 308s
+        f"/{ledger}/help/{slug}"
+        for slug in HELP_PAGES
+        if slug != "_index"
+    ]
+    for url in urls:
+        response = test_client.get(url)
+        assert response.status_code == 200, (
+            f"GET {url} -> {response.status_code}"
+        )
+
+
+@pytest.mark.parametrize("ledger", LEDGER_SLUGS)
+def test_all_api_endpoints_respond(
+    test_client: FlaskClient, ledger: str
+) -> None:
+    """Layer 2: every no-argument API endpoint returns 200."""
+    for endpoint in API_ENDPOINTS:
+        url = f"/{ledger}/api/{endpoint}"
+        if endpoint == "journal":
+            url = f"/{ledger}/api/journal_page?page=1&order=desc"
+        response = test_client.get(url)
+        assert response.status_code == 200, (
+            f"GET {url} -> {response.status_code}"
+        )
+
+
+@pytest.mark.parametrize("ledger", LEDGER_SLUGS)
+def test_all_frontend_queries_execute(
+    test_client: FlaskClient, ledger: str
+) -> None:
+    """Layer 3: every query the frontend ships executes on every ledger.
+
+    This is the regression class of #190: the Holdings page ran a query via
+    ``/api/query`` that failed compilation on any ledger with cost-dated
+    lots, and nothing server-side ever executed it.
+    """
+    for query in _frontend_queries():
+        response = test_client.get(
+            f"/{ledger}/api/query", query_string={"query_string": query}
+        )
+        if response.status_code != 200:
+            body = response.get_data(as_text=True)
+            assert _known_engine_gap(body), (
+                f"query failed on {ledger} ({response.status_code}): "
+                f"{query[:80]}\nbody: {body[:200]}"
+            )
+
+
+def test_known_engine_gaps_are_still_present(test_client: FlaskClient) -> None:
+    """The gap list must shrink, not rot: when rustledger#1699 ships, the
+    fixed marker must be removed so the affected queries are asserted again."""
+    hit: set[str] = set()
+    for query in _frontend_queries():
+        response = test_client.get(
+            "/example/api/query", query_string={"query_string": query}
+        )
+        if response.status_code != 200:
+            body = response.get_data(as_text=True)
+            hit.update(m for m in KNOWN_ENGINE_GAPS if m in body)
+    for marker in KNOWN_ENGINE_GAPS:
+        if marker == "ABS expects a number":
+            continue  # only triggered by the errors ledger, checked implicitly
+        assert marker in hit, (
+            f"engine gap {marker!r} appears FIXED - remove it from "
+            "KNOWN_ENGINE_GAPS so the affected queries are asserted again"
+        )


### PR DESCRIPTION
Items 1+2 of the project-review action list: catch user-visible breakage before users do, and put the highest-risk files under the coverage gate.

## 1. Kitchen-sink route smoke (`tests/test_smoke_routes.py`, 29 tests)
Every page shell + server route, every no-arg API endpoint, and **every BQL query embedded in the frontend report sources** (extracted from the TS at test time, so a frontend query change can't silently drift out of coverage — the exact #190 failure shape), all × 9 corpus ledgers.

**First run caught three engine bugs live in released v1.31.0**, filed upstream:
- **rustledger#1699** — `only()`/`abs()` type-error on NULL instead of propagating it: the Holdings *by currency* page 500s on most real ledgers today. Excused via an error-body gap list; a guard test forces the list to shrink when the engine fix ships.
- **rustledger#1700** — `{a # b}` cost weight wrong in all three forms (valid ledgers rejected, invalid accepted).
- **rustledger#1701** — query column declared `Amount` carrying an Inventory-shaped payload; rustfava's row marshalling crashed on it (`KeyError` → HTTP 500 for the whole query). **Fixed here**: `_convert_row_value` now shape-sniffs and degrades gracefully.

## 2. Coverage burn-down
The `rustledger/*` omit glob becomes explicit per-file entries; the two files where every recent bug lived join the enforced gate:
- **`query.py` 53% → 100%** — cursor protocol, every conversion branch, both engine styles through `execute()`, error mapping
- **`component_engine.py` 88% → 100%** — download fallback, `result<ok,err>` lifting, `_default_for`, pair-list/variant tolerance branches, guest-path rewriting; **every wasmtime type instance harvested from the real component**, no fabricated WIT mocks
- `constants.py` covered rather than omitted

Remaining exempt (documented in `pyproject.toml`): `backend.py`, `engine.py`, `loader.py`, `options.py`, `types.py`, `__init__.py` — next burn-down targets.

## Validation
Full suite **629 passed, 100.00% under the tightened gate**; ruff (pinned) + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)