### PR TITLE
test(coverage): burn-down phase 2 — zero rustledger exemptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,15 +193,6 @@ omit = [
     "src/rustfava/_version.py",
     "src/rustfava/beans/types.py",
     "src/rustfava/ext/auto_commit.py",
-    # Rustledger integration - new code with many error handling paths.
-    # Being burned down file by file: query.py and component_engine.py are
-    # now measured; the rest remain exempt.
-    "src/rustfava/rustledger/__init__.py",
-    "src/rustfava/rustledger/backend.py",
-    "src/rustfava/rustledger/engine.py",
-    "src/rustfava/rustledger/loader.py",
-    "src/rustfava/rustledger/options.py",
-    "src/rustfava/rustledger/types.py",
     "src/rustfava/beans/create.py",
     "src/rustfava/beans/str.py",
     "src/rustfava/beans/abc.py",

--- a/src/rustfava/rustledger/loader.py
+++ b/src/rustfava/rustledger/loader.py
@@ -93,8 +93,8 @@ def _compute_display_precision(
     # Get most common precision for each currency
     result = {}
     for currency, counts in precision_counts.items():
-        if counts:
-            result[currency] = counts.most_common(1)[0][0]
+        # counts is never empty: the Counter is created on first tracked amount
+        result[currency] = counts.most_common(1)[0][0]
 
     return result
 

--- a/src/rustfava/rustledger/types.py
+++ b/src/rustfava/rustledger/types.py
@@ -879,7 +879,9 @@ def directive_to_json(  # noqa: PLR0912, PLR0915 - per-directive-type serializer
         result["name"] = getattr(directive, "name", "")
         result["query_string"] = getattr(directive, "query_string", "")
 
-    elif type_name == "custom":
+    else:
+        # custom — the only remaining member of DIRECTIVE_TYPES (membership
+        # was enforced when type_name was resolved above)
         result["custom_type"] = getattr(directive, "type", "")
         # Custom values need special handling
         values = []

--- a/tests/test_rustledger_loader_plugins.py
+++ b/tests/test_rustledger_loader_plugins.py
@@ -1,0 +1,247 @@
+"""The Python-plugin runner's dispatch and error-conversion branches.
+
+Coverage burn-down phase 2 for ``rustfava.rustledger.loader`` — the plugin
+runner is host-side code the differential corpus doesn't reach (its fixtures
+declare no Python plugins).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from typing import cast
+from typing import ClassVar
+from typing import TYPE_CHECKING
+
+from rustfava.helpers import BeancountError
+from rustfava.rustledger import loader as loader_mod
+from rustfava.rustledger.loader import _compute_display_precision
+from rustfava.rustledger.loader import _errors_from_json
+from rustfava.rustledger.loader import _run_plugins
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _options() -> Any:
+    return cast("Any", {})
+
+
+def _entries(items: list[str]) -> Any:
+    """Sentinel strings standing in for directives (opaque to plugins)."""
+    return cast("Any", items)
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, name: str, **attrs: Any) -> None:
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+
+
+def test_auto_accounts_is_skipped() -> None:
+    entries, errors = _run_plugins(
+        [], [{"name": "auto_accounts"}, {"name": ""}], _options()
+    )
+    assert list(entries) == cast("Any", [])
+    assert errors == []
+
+
+def test_missing_plugin_reports_import_error() -> None:
+    _, errors = _run_plugins(
+        [], [{"name": "no.such.plugin.module"}], _options()
+    )
+    assert len(errors) == 1
+    assert "Failed to import plugin" in errors[0].message
+
+
+def test_plugin_via_dunder_plugins(monkeypatch: pytest.MonkeyPatch) -> None:
+    def stamp(
+        entries: list[Any], _options: Any
+    ) -> tuple[list[Any], list[Any]]:
+        return [*entries, "stamped"], []
+
+    _install(monkeypatch, "fake_plugin_a", __plugins__=["stamp"], stamp=stamp)
+    entries, errors = _run_plugins(
+        _entries(["seed"]), [{"name": "fake_plugin_a"}], _options()
+    )
+    assert list(entries) == cast("Any", ["seed", "stamped"])
+    assert errors == []
+
+
+def test_plugin_via_module_name_fallback_and_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No __plugins__: the module-name function runs, receiving the config."""
+    seen: list[Any] = []
+
+    def tail(entries: list[Any], config: Any) -> tuple[list[Any], list[Any]]:
+        seen.append(config)
+        return entries, []
+
+    _install(monkeypatch, "tail", tail=tail)
+    _run_plugins(
+        _entries([]), [{"name": "tail", "config": "cfg-string"}], _options()
+    )
+    assert seen == ["cfg-string"]
+
+
+def test_plugin_missing_function_is_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install(monkeypatch, "fake_plugin_b", __plugins__=["absent"])
+    entries, errors = _run_plugins(
+        _entries(["seed"]), [{"name": "fake_plugin_b"}], _options()
+    )
+    assert list(entries) == cast("Any", ["seed"])
+    assert errors == []
+
+
+def test_plugin_errors_are_converted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BeancountError passes through; foreign error objects are adapted;
+    a raising plugin becomes an error entry rather than a crash."""
+    native = BeancountError(
+        source={"filename": "x", "lineno": 1}, message="native", entry=None
+    )
+
+    class ForeignError:
+        message = "foreign"
+        entry = None
+
+    def emits(entries: list[Any], _o: Any) -> tuple[list[Any], list[Any]]:
+        return entries, [native, ForeignError()]
+
+    def boom(_entries: list[Any], _o: Any) -> tuple[list[Any], list[Any]]:
+        message = "kaboom"
+        raise RuntimeError(message)
+
+    _install(
+        monkeypatch,
+        "fake_plugin_c",
+        __plugins__=["emits", "boom"],
+        emits=emits,
+        boom=boom,
+    )
+    entries, errors = _run_plugins(
+        _entries(["seed"]), [{"name": "fake_plugin_c"}], _options()
+    )
+    assert list(entries) == cast("Any", ["seed"])
+    messages = [e.message for e in errors]
+    assert messages[0] == "native"
+    assert messages[1] == "foreign"
+    assert "raised: kaboom" in messages[2]
+
+
+def test_plugin_module_without_matching_function(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No __plugins__ and no module-name function: nothing runs, no error."""
+    _install(monkeypatch, "inert_plugin")
+    entries, errors = _run_plugins(
+        _entries(["seed"]), [{"name": "inert_plugin"}], _options()
+    )
+    assert list(entries) == cast("Any", ["seed"])
+    assert errors == []
+
+
+def test_display_precision_skips_malformed_amounts() -> None:
+    precision = _compute_display_precision(
+        [
+            {
+                "type": "transaction",
+                "postings": [
+                    {"units": {"number": "1.25", "currency": "USD"}},
+                    {"units": {"number": "", "currency": "USD"}},
+                    {"units": {"number": "3", "currency": ""}},
+                    {"units": None},
+                    {"units": {"number": "7", "currency": "JPY"}},
+                ],
+            }
+        ]
+    )
+    assert precision["USD"] == 2
+    assert precision["JPY"] == 0
+
+
+def test_errors_from_json_source_formats() -> None:
+    old_format = {
+        "message": "boom",
+        "source": {"filename": "inc.beancount", "lineno": 7},
+    }
+    new_format = {"message": "pow", "line": 3}
+    suppressed = {"message": "plugin x requires the python-plugins feature"}
+    errors = _errors_from_json(
+        [old_format, new_format, suppressed], filename="main.beancount"
+    )
+    assert len(errors) == 2
+    assert errors[0].source == {"filename": "inc.beancount", "lineno": 7}
+    source = errors[1].source
+    assert source is not None
+    assert source["filename"] == "main.beancount"
+
+
+def test_display_precision_currency_without_samples() -> None:
+    """A currency tracked but with no countable precisions is skipped."""
+    assert (
+        _compute_display_precision([{"type": "transaction", "postings": []}])
+        == {}
+    )
+
+
+def test_load_string_keeps_ffi_display_precision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the engine provides display_precision, the workaround is skipped
+    (no engine currently sends it — the branch guards the planned FFI
+    field)."""
+
+    class StubEngine:
+        # a plugin spec exercises load_string's plugin dispatch;
+        # auto_accounts is the no-op skip
+        plugins: ClassVar[list[dict[str, Any]]] = [{"name": "auto_accounts"}]
+
+        @classmethod
+        def load(cls, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "entries": [],
+                "errors": [],
+                "options": {"display_precision": {"USD": 2}},
+                "plugins": cls.plugins,
+            }
+
+    monkeypatch.setattr(loader_mod, "get_engine", lambda: StubEngine())
+    entries, errors, _options = loader_mod.load_string(
+        "2020-01-01 open Assets:Cash\n", "<t>"
+    )
+    assert entries == []
+    assert errors == []
+
+    # and the no-plugins path
+    StubEngine.plugins = []
+    entries, errors, _options = loader_mod.load_string("", "<t>")
+    assert entries == []
+
+
+def test_load_uncached_keeps_ffi_display_precision(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """load_uncached has its own copy of the precision workaround; the
+    FFI-provided branch is engine-version-gated like load_string's."""
+    class StubEngine:
+        @staticmethod
+        def load_full(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "entries": [],
+                "errors": [],
+                "options": {"display_precision": {"USD": 2}},
+                "plugins": [],
+            }
+
+        load = load_full
+
+    monkeypatch.setattr(loader_mod, "get_engine", lambda: StubEngine())
+    ledger = tmp_path / "t.beancount"
+    ledger.write_text("")
+    entries, _errors, _options = loader_mod.load_uncached(str(ledger))
+    assert entries == []

--- a/tests/test_rustledger_support_units.py
+++ b/tests/test_rustledger_support_units.py
@@ -1,0 +1,72 @@
+"""Unit coverage for the small rustledger support modules.
+
+Part of the coverage burn-down phase 2 (backend.py, options.py, loader.py
+edges) — these were exempt from the 100% gate until now.
+"""
+
+from __future__ import annotations
+
+import builtins
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from rustfava.rustledger.backend import get_engine
+from rustfava.rustledger.engine import RustledgerError
+from rustfava.rustledger.options import _RLCurrencyContext
+from rustfava.rustledger.options import RLBooking
+from rustfava.rustledger.options import RLDisplayContext
+from rustfava.rustledger.options import RLDisplayFormatter
+
+
+def test_get_engine_missing_wasmtime_is_actionable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken install (no component engine import) raises RustledgerError
+    with a reinstall hint, not a bare ImportError."""
+    real_import = builtins.__import__
+
+    def block_component(name: str, *args: Any, **kwargs: Any) -> Any:
+        if "component_engine" in name:
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", block_component)
+    with pytest.raises(RustledgerError, match="wasmtime"):
+        get_engine()
+
+
+def test_display_formatter_precision_and_commas() -> None:
+    ctx = RLDisplayContext(
+        {"display_precision": {"USD": 2, "JPY": 0}, "render_commas": True}
+    )
+    formatter = ctx.build()
+    assert formatter.format(Decimal("1234567.891"), "USD") == "1,234,567.89"
+    assert formatter.format(Decimal("1234567.891"), "JPY") == "1,234,568"
+    # unknown currency falls back to 2 decimal places
+    assert formatter.format(Decimal("1.005"), "XXX") == "1.00"
+
+
+def test_display_formatter_without_commas_and_quantize() -> None:
+    formatter = RLDisplayFormatter({"USD": 2}, render_commas=False)
+    assert formatter.format(Decimal("1234.5"), "USD") == "1234.50"
+    assert formatter.quantize(Decimal("1.005"), "USD") == Decimal("1.00")
+    assert formatter.quantize(Decimal("1.005"), "ZZZ") == Decimal("1.00")
+
+
+def test_booking_equality_semantics() -> None:
+    strict = RLBooking("STRICT")
+    assert strict == "strict"
+    assert strict == RLBooking("STRICT")
+    assert strict != RLBooking("FIFO")
+    assert strict != 42
+
+
+def test_booking_str_hash_and_currency_context() -> None:
+    assert str(RLBooking("FIFO")) == "FIFO"
+    # __eq__ without __hash__ makes RLBooking unhashable (beancount's
+    # Booking enum IS hashable) — documented current behavior.
+    with pytest.raises(TypeError, match="unhashable"):
+        hash(RLBooking("FIFO"))
+    assert _RLCurrencyContext(4).get_fractional() == 4

--- a/tests/test_rustledger_types_units.py
+++ b/tests/test_rustledger_types_units.py
@@ -1,0 +1,256 @@
+"""Unit coverage for ``rustfava.rustledger.types`` edge branches.
+
+Coverage burn-down phase 2: FrozenDict semantics, cost-number wire-format
+tolerance (v0.20 list / v0.19 fields / flat scalar), typed custom values,
+and the directive JSON adapters' error paths.
+"""
+
+from __future__ import annotations
+
+import copy
+import datetime
+from decimal import Decimal
+from typing import Any
+from typing import cast
+from typing import ClassVar
+
+import pytest
+
+from rustfava.rustledger.types import _amount_to_json
+from rustfava.rustledger.types import _cost_to_json
+from rustfava.rustledger.types import _parse_meta
+from rustfava.rustledger.types import cost_number_values
+from rustfava.rustledger.types import directive_from_json
+from rustfava.rustledger.types import directive_to_json
+from rustfava.rustledger.types import FrozenDict
+from rustfava.rustledger.types import RLAmount
+from rustfava.rustledger.types import RLCost
+from rustfava.rustledger.types import RLCustom
+from rustfava.rustledger.types import RLCustomValue
+from rustfava.rustledger.types import RLPosition
+
+
+def test_frozen_dict_is_immutable_but_copyable() -> None:
+    frozen = FrozenDict({"b": [1, {"z": 2}], "a": 1})
+    with pytest.raises(TypeError, match="immutable"):
+        frozen["c"] = 3
+    with pytest.raises(TypeError, match="immutable"):
+        del frozen["a"]
+    assert isinstance(hash(frozen), int)
+    assert hash(frozen) == hash(FrozenDict({"a": 1, "b": [1, {"z": 2}]}))
+    assert copy.copy(frozen) == {"a": 1, "b": [1, {"z": 2}]}
+    deep = copy.deepcopy(frozen)
+    assert deep == frozen
+    assert isinstance(deep, dict)
+    assert not isinstance(deep, FrozenDict)
+
+
+def test_cost_number_values_wire_formats() -> None:
+    # v0.20: type-tagged, pair as list
+    assert cost_number_values(
+        {"type": "per_unit_from_total", "value": ["2", "10"]}
+    ) == (Decimal(2), Decimal(10))
+    # v0.19: kind-tagged, pair spread as fields
+    assert cost_number_values(
+        {"kind": "per_unit_from_total", "per_unit": "3", "total": "9"}
+    ) == (Decimal(3), Decimal(9))
+    assert cost_number_values({"kind": "total", "value": "7"}) == (
+        None,
+        Decimal(7),
+    )
+    # unknown kind degrades to no cost number
+    assert cost_number_values({"kind": "mystery", "value": "1"}) == (
+        None,
+        None,
+    )
+    # flat scalar (JSON-RPC era) is a per-unit cost
+    assert cost_number_values("4.5") == (Decimal("4.5"), None)
+    assert cost_number_values(None) == (None, None)
+
+
+def test_cost_from_json_computes_per_unit_from_total() -> None:
+    cost = RLCost.from_json(
+        {"number_total": "10", "currency": "USD"},
+        units_number=Decimal(4),
+    )
+    assert cost is not None
+    assert cost.number == Decimal("2.5")
+
+
+def test_position_requires_units() -> None:
+    with pytest.raises(ValueError, match="requires units"):
+        RLPosition.from_json({"units": None})
+
+
+def test_custom_value_typed_dict_branches() -> None:
+    amount = RLCustomValue.from_raw(
+        {"type": "amount", "value": {"number": "20.00", "currency": "EUR"}}
+    )
+    assert amount.value == RLAmount(number=Decimal("20.00"), currency="EUR")
+    amount_str = RLCustomValue.from_raw({"type": "amount", "value": "5 USD"})
+    assert amount_str.value == RLAmount(number=Decimal(5), currency="USD")
+    odd_amount = RLCustomValue.from_raw(
+        {"type": "amount", "value": "just-text"}
+    )
+    assert odd_amount.value == "just-text"
+    account = RLCustomValue.from_raw(
+        {"type": "account", "value": "Expenses:Books"}
+    )
+    assert account.value == "Expenses:Books"
+    a_date = RLCustomValue.from_raw({"type": "date", "value": "2020-01-02"})
+    assert a_date.value == datetime.date(2020, 1, 2)
+    null_date = RLCustomValue.from_raw({"type": "date", "value": None})
+    assert null_date.value is None
+    unknown = RLCustomValue.from_raw({"type": "wobble", "value": 9})
+    assert unknown.value == 9
+
+
+def test_custom_value_untyped_fallbacks() -> None:
+    assert RLCustomValue.from_raw(Decimal(3)).value == Decimal(3)
+    parsed = RLCustomValue.from_raw("12.5 CHF")
+    assert parsed.value == RLAmount(number=Decimal("12.5"), currency="CHF")
+    # two tokens that are not an amount stay a string
+    assert RLCustomValue.from_raw("hello world").value == "hello world"
+    assert RLCustomValue.from_raw("plain").value == "plain"
+    assert str(RLCustomValue.from_raw("plain")) == "plain"
+
+
+def test_directive_json_unknown_types_raise() -> None:
+    with pytest.raises(ValueError, match="Unknown directive type"):
+        directive_from_json({"type": "no-such-directive"})
+
+    class NotADirective:
+        date = datetime.date(2020, 1, 1)
+
+    with pytest.raises(ValueError, match="Unknown directive type"):
+        directive_to_json(NotADirective())  # type: ignore[arg-type]
+
+
+def test_position_meta_normalization_and_cost() -> None:
+    pos = RLPosition.from_json(
+        {
+            "units": {"number": "1", "currency": "USD"},
+            "cost": {"number": "2", "currency": "EUR", "date": "2020-01-01"},
+        }
+    )
+    assert pos.cost is not None
+    assert pos.cost.number == Decimal(2)
+
+
+def test_custom_value_int_bool_and_two_token_currency_check() -> None:
+    assert RLCustomValue.from_raw(
+        {"type": "int", "value": 10}
+    ).value == Decimal(10)
+    truthy = RLCustomValue.from_raw({"type": "bool", "value": True})
+    assert truthy.value is True
+    # two tokens whose second part is not an UPPERCASE currency stay a string
+    assert RLCustomValue.from_raw("5 apples").value == "5 apples"
+    # non-decimal first token falls through the amount parse
+    assert RLCustomValue.from_raw("five USD").value == "five USD"
+
+
+def test_amount_and_cost_json_serializers() -> None:
+    assert _amount_to_json(None) is None
+    assert _amount_to_json(RLAmount(number=Decimal(1), currency="USD")) == {
+        "number": "1",
+        "currency": "USD",
+    }
+    assert _cost_to_json(None) is None
+    full = RLCost(
+        number=Decimal(2),
+        currency="EUR",
+        date=datetime.date(2020, 1, 1),
+        label="lot",
+    )
+    assert _cost_to_json(full) == {
+        "number": "2",
+        "currency": "EUR",
+        "date": "2020-01-01",
+        "label": "lot",
+    }
+    empty = cast("Any", RLCost)(
+        number=None, currency=None, date=None, label=None
+    )
+    assert _cost_to_json(empty) is None
+
+
+def test_directive_to_json_transaction_and_custom_values() -> None:
+    class Transaction:
+        """Duck-typed beancount-style transaction: exercises the class-name
+        fallback in type resolution and the tolerance/diff_amount getattrs
+        (RLTransaction has neither field)."""
+
+        meta: ClassVar[dict[str, Any]] = {"filename": "f", "lineno": 1}
+        date = datetime.date(2020, 1, 2)
+        flag = "*"
+        payee = None
+        narration = "n"
+        tags: frozenset[str] = frozenset()
+        links: frozenset[str] = frozenset()
+        postings: ClassVar[list[object]] = []
+
+    out = directive_to_json(Transaction())  # type: ignore[arg-type]
+    assert out["type"] == "transaction"
+    assert out["flag"] == "*"
+    assert out["postings"] == []
+
+    class Balance:
+        meta: ClassVar[dict[str, Any]] = {"filename": "f", "lineno": 5}
+        date = datetime.date(2020, 1, 4)
+        account = "Assets:Cash"
+        amount = RLAmount(number=Decimal(3), currency="USD")
+        tolerance = Decimal("0.005")
+        diff_amount = RLAmount(number=Decimal(1), currency="USD")
+
+    out = directive_to_json(Balance())  # type: ignore[arg-type]
+    assert out["tolerance"] == "0.005"
+    assert out["diff_amount"] == {"number": "1", "currency": "USD"}
+
+    custom: Any = RLCustom(
+        meta={"filename": "f", "lineno": 2},
+        date=datetime.date(2020, 1, 3),
+        type="budget",
+        values=[
+            RLCustomValue(
+                RLAmount(number=Decimal(5), currency="USD"), dtype=object
+            ),
+            RLCustomValue("txt"),
+            cast("Any", "bare"),
+        ],
+    )
+    out = directive_to_json(custom)
+    assert out["values"][0] == {
+        "type": "amount",
+        "number": "5",
+        "currency": "USD",
+    }
+    assert out["values"][1] == {"type": "string", "value": "txt"}
+    assert out["values"][2] == "bare"
+
+
+def test_parse_meta_fills_and_coerces() -> None:
+    bare = _parse_meta({})
+    assert bare["filename"] == "<unknown>"
+    assert bare["lineno"] == 0
+    coerced = _parse_meta({"meta": {"filename": "f", "lineno": "7"}})
+    assert coerced["lineno"] == 7
+
+
+def test_directive_to_json_metaless_and_asdict_values() -> None:
+    class Custom:
+        date = datetime.date(2020, 1, 5)
+        type = "budget"
+        values: ClassVar[list[Any]] = []
+
+    out = directive_to_json(Custom())  # type: ignore[arg-type]
+    assert "meta" not in out
+    assert out["values"] == []
+
+    class AsDictValue:
+        @staticmethod
+        def _asdict() -> dict[str, Any]:
+            return {"shape": "asdict"}
+
+    Custom.values = [AsDictValue()]
+    out = directive_to_json(Custom())  # type: ignore[arg-type]
+    assert out["values"] == [{"shape": "asdict"}]


### PR DESCRIPTION
**Stacked on #237** (the v0.20.1 upgrade — merge that first; this contains its commits until then).

Completes the coverage burn-down: every remaining `rustledger/*` exemption is deleted from `pyproject.toml`. 30 new unit tests:

| File | Before | After |
|---|---|---|
| `backend.py` | 70% | **100%** — actionable broken-install error |
| `options.py` | 60% | **100%** — display formatting, quantize, `RLBooking` semantics (documents that it's unhashable, unlike beancount's enum) |
| `loader.py` | 84% | **100%** — the whole Python-plugin runner (import failure, `__plugins__`/module-name dispatch, config, foreign-error adaptation, raising plugins), both error wire formats, FFI-precision branches in *both* load paths via a stubbed engine; deletes one provably-dead guard |
| `types.py` | 80% | **100%** — FrozenDict, all three cost-number wire generations, typed custom values, meta normalization, serializer edges via duck-typed beancount-style stubs; the unreachable `elif`-chain exit eliminated structurally (last `elif` → `else`, membership enforced at type resolution) |
| `engine.py`, `__init__.py` | 100% | exemptions simply dropped |

Also from this work session: item 3 of the improvement list (mutation-endpoint smoke) verified **already satisfied** by existing `test_json_api` coverage, and item 4 (`abs(NULL)`) fixed upstream as rustledger#1711.

## Validation
**659 passed, 100.00% with no `rustledger/` exemptions for the first time**; pinned ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)