### PR TITLE
feat: rustledger v0.20.2 — gap re-arm, WIT 3.3 compound handling

### DIFF
--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -324,7 +324,7 @@ def _cost_number_from_json(value: Any) -> Any:
                 return Variant(tag, (str(payload[0]), str(payload[1])))
             # v0.19 spread the pair as per_unit/total fields
             return Variant(tag, (str(value["per_unit"]), str(value["total"])))
-        if tag == "compound":
+        if tag == "compound" and isinstance(payload, (list, tuple)):
             # WIT 3.3 input case (rustledger#1700): `{a # b}` as written —
             # (per-unit, LUMP-total). Pre-booking surfaces only; booked
             # egress rewrites to per-unit-from-total (rustfava#234).

--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -324,6 +324,11 @@ def _cost_number_from_json(value: Any) -> Any:
                 return Variant(tag, (str(payload[0]), str(payload[1])))
             # v0.19 spread the pair as per_unit/total fields
             return Variant(tag, (str(value["per_unit"]), str(value["total"])))
+        if tag == "compound":
+            # WIT 3.3 input case (rustledger#1700): `{a # b}` as written —
+            # (per-unit, LUMP-total). Pre-booking surfaces only; booked
+            # egress rewrites to per-unit-from-total (rustfava#234).
+            return Variant(tag, (str(payload[0]), str(payload[1])))
         return Variant(tag, str(payload))
     # A bare scalar (``_cost_to_json``'s flat string) is a per-unit cost.
     return Variant("per-unit", str(value))

--- a/src/rustfava/rustledger/engine.py
+++ b/src/rustfava/rustledger/engine.py
@@ -22,7 +22,7 @@ SUPPORTED_API_MAJOR = 3
 # Rustledger release this build is pinned to. The component wasm
 # (``rustledger-ffi-component-<version>.wasm``) is downloaded lazily from this
 # release by ``component_engine``. Bumped by ``update-rustledger.yml``.
-RUSTLEDGER_VERSION = "v0.20.1"
+RUSTLEDGER_VERSION = "v0.20.2"
 
 
 class RustledgerError(Exception):

--- a/src/rustfava/rustledger/types.py
+++ b/src/rustfava/rustledger/types.py
@@ -118,8 +118,14 @@ def cost_number_values(
             return Decimal(raw["value"]), None
         if kind == "total":
             return None, Decimal(raw["value"])
-        if kind == "per_unit_from_total":
-            # v0.20 sends the pair as a list; v0.19 spread it as fields
+        if kind in ("per_unit_from_total", "compound"):
+            # Both carry a two-string pair. v0.20 sends it as a list
+            # (v0.19 spread per_unit_from_total as fields). For compound
+            # (WIT 3.3, rustledger#1700, `{a # b}` as written) the second
+            # element is only the LUMP component — the effective per-unit
+            # is (N*a+b)/N, not derivable here; booked egress never
+            # carries compound, so it only shows pre-booking
+            # (rustfava#234).
             pair = (
                 value
                 if isinstance(value, (list, tuple))

--- a/tests/test_rustledger_component_marshal.py
+++ b/tests/test_rustledger_component_marshal.py
@@ -142,6 +142,9 @@ def test_cost_number_from_json_shapes() -> None:
     assert (v.tag, v.payload) == ("per-unit-from-total", ("2", "10"))
     v = ce._cost_number_from_json({"type": "total", "value": "10"})
     assert (v.tag, v.payload) == ("total", "10")
+    # WIT 3.3 compound input case (rustledger#1700, rustfava#234)
+    v = ce._cost_number_from_json({"type": "compound", "value": ["5", "10"]})
+    assert (v.tag, v.payload) == ("compound", ("5", "10"))
     v = ce._cost_number_from_json("3.5")
     assert (v.tag, v.payload) == ("per-unit", "3.5")
 

--- a/tests/test_rustledger_types_units.py
+++ b/tests/test_rustledger_types_units.py
@@ -58,6 +58,12 @@ def test_cost_number_values_wire_formats() -> None:
         None,
         Decimal(7),
     )
+    # WIT 3.3 compound `{a # b}` (rustledger#1700): per-unit + LUMP —
+    # pre-booking surfaces only (rustfava#234)
+    assert cost_number_values({"type": "compound", "value": ["5", "10"]}) == (
+        Decimal(5),
+        Decimal(10),
+    )
     # unknown kind degrades to no cost number
     assert cost_number_values({"kind": "mystery", "value": "1"}) == (
         None,

--- a/tests/test_smoke_routes.py
+++ b/tests/test_smoke_routes.py
@@ -68,16 +68,13 @@ _FRONTEND_REPORTS = (
     Path(__file__).parent.parent / "frontend" / "src" / "reports"
 )
 
-# Engine shortfalls tracked upstream: abs() (and possibly other typed scalar
-# functions) type-error on NULL instead of propagating it like beanquery —
-# https://github.com/rustledger/rustledger/issues/1699 (only() was fixed in
-# v0.20.0; abs() still errors as of v0.20.1). Matched against the error BODY
-# so queries are only excused for the known gap on the ledgers that trigger
-# it. Remove entries when the engine fix ships — the guard test below
-# enforces removal.
-KNOWN_ENGINE_GAPS = [
-    "ABS expects a number",
-]
+# Engine shortfalls tracked upstream, matched against the error BODY so
+# queries are only excused for a known gap on the ledgers that trigger it.
+# Remove entries when the engine fix ships — the guard test below enforces
+# removal. Currently EMPTY: rustledger#1699 (abs()/typed scalars on NULL)
+# was completed by rustledger#1711, shipped in v0.20.2. The scaffolding
+# stays for the next gap.
+KNOWN_ENGINE_GAPS: list[str] = []
 
 
 def _known_engine_gap(body: str) -> bool:
@@ -179,21 +176,15 @@ def test_all_frontend_queries_execute(
             )
 
 
-def test_known_engine_gaps_are_still_present(test_client: FlaskClient) -> None:
+def test_known_engine_gaps_are_still_present() -> None:
     """The gap list must shrink, not rot: when the engine fix ships, the
     fixed marker must be removed so the affected queries are asserted again.
-    The errors-corpus ledger is the trigger for the abs()-on-NULL gap."""
-    assert KNOWN_ENGINE_GAPS, "gap list is empty - delete this test too"
-    hit: set[str] = set()
-    for query in _frontend_queries():
-        response = test_client.get(
-            "/errors/api/query", query_string={"query_string": query}
-        )
-        if response.status_code != 200:
-            body = response.get_data(as_text=True)
-            hit.update(m for m in KNOWN_ENGINE_GAPS if m in body)
-    for marker in KNOWN_ENGINE_GAPS:
-        assert marker in hit, (
-            f"engine gap {marker!r} appears FIXED - remove it from "
-            "KNOWN_ENGINE_GAPS so the affected queries are asserted again"
-        )
+
+    With the list currently empty this asserts exactly that emptiness (every
+    frontend query must succeed un-excused — the smoke test above covers it);
+    when a new gap is excused, restore the marker-hit assertion from git
+    history (see the pre-v0.20.2 version of this test)."""
+    assert not KNOWN_ENGINE_GAPS, (
+        "a gap entry was added - restore the marker-hit assertion body "
+        "from git history so the entry is guarded against rot"
+    )


### PR DESCRIPTION
Engine bump **v0.20.1 → v0.20.2**, delivering rustledger#1711 (typed scalars propagate NULL, beanquery parity).

**Gap re-arm**: `ABS expects a number` removed from `KNOWN_ENGINE_GAPS` — the Holdings queries excused since #1699 are asserted un-excused again (verified both directions: failing on v0.20.1, passing on v0.20.2). The list is now **empty**; the guard test asserts emptiness and documents how to restore the marker-hit body when the next gap appears.

**WIT 3.3 `compound` cost-number** (closes #234): handled at both branch sites — `_cost_number_from_json` builds the two-string tuple Variant (input surface, the only place compound appears; booked egress rewrites to `per-unit-from-total`), and `cost_number_values` extracts (per-unit, LUMP) for pre-booking display. Tests for both.

Full suite: **659 passed, 1 skipped** against the v0.20.2 component.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)