### PR TITLE
fix(updater): scope bot commits to engine.py; drop unconsumed root component.wasm

### DIFF
--- a/.github/workflows/update-rustledger.yml
+++ b/.github/workflows/update-rustledger.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Rustledger version (e.g., v0.8.5)'
+        description: "Rustledger version (e.g., v0.8.5)"
         required: true
         type: string
 
@@ -153,7 +153,7 @@ jobs:
             cat > pr-body.md <<EOF
           Automated update of rustledger WASM version to ${VERSION}.
 
-          The component's WIT version is unchanged (\`${{ steps.gate.outputs.cur_wit }}\`) and the release notes carry no breaking markers, so this auto-merges once CI passes. The vendored component was refreshed and sha256-verified.
+          The component's WIT version matches the host bindings (\`${{ steps.gate.outputs.cur_wit }}\`) and the release notes carry no breaking markers, so this auto-merges once CI passes. The component was sha256-verified against the release asset.
 
           See [rustledger releases](https://github.com/rustledger/rustledger/releases) for the changelog.
           EOF
@@ -183,6 +183,13 @@ jobs:
           commit-message: "chore: upgrade rustledger to ${{ steps.version.outputs.version }}"
           title: "chore: upgrade rustledger to ${{ steps.version.outputs.version }}"
           body-path: pr-body.md
+          # Only engine.py is an intended repo change. The root component.wasm
+          # / .sha256 / pr-body.md are workflow-run working files; without
+          # this scoping create-pull-request committed them, shipping ~6 MB
+          # of unconsumed sdist weight per release that also went silently
+          # stale on manual bumps (#243).
+          add-paths: |
+            src/rustfava/rustledger/engine.py
           branch: chore/upgrade-rustledger-${{ steps.version.outputs.version }}
           delete-branch: true
           draft: ${{ steps.gate.outputs.needs_review }}

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ npm-debug.log
 # Rustledger build artifacts
 /src/rustfava/rustledger/.wasm-version
 /src/rustfava/rustledger/*.wasm
+
+# update-rustledger workflow working files (never commit — #243)
+component.wasm
+component.wasm.sha256
+pr-body.md

--- a/component.wasm.sha256
+++ b/component.wasm.sha256
@@ -1,1 +1,0 @@
-94d69bbe714934ea46c366ea555b24e7f7bbe817f7c293aa90f6b4b4d98f7af5  rustledger-ffi-component-v0.20.2.wasm

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,5 +1,0 @@
-Automated update of rustledger WASM version to v0.20.2.
-
-The component's WIT version is unchanged (`3.3.0`) and the release notes carry no breaking markers, so this auto-merges once CI passes. The vendored component was refreshed and sha256-verified.
-
-See [rustledger releases](https://github.com/rustledger/rustledger/releases) for the changelog.


### PR DESCRIPTION
Executes #243 (post-review scope — claim 1 was retracted after verifying the #220 gate is sound):

1. **`add-paths: engine.py`** on create-pull-request — the root cause of the stray files: without scoping, the action committed every dirty working file, which is how root `component.wasm`/`.sha256` and even the bot's own `pr-body.md` became tracked. All three removed (verified consumed by **nothing**: CI downloads by `RUSTLEDGER_VERSION` + verifies against the release's own sha asset; runtime loads package data with env override + download fallback) and gitignored. ~6 MB sdist weight per release gone; the silent-staleness class (v0.19.1 pin surviving two releases) is structurally closed.
2. **PR-body wording**: 'WIT version is unchanged' → 'matches the host bindings' — the comparison is component-vs-host-`_WIT_VERSION` (correct and safety-relevant), and the old phrasing invited the misreading that spawned this issue.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)