### PR TITLE
test: cover the bundled wasm-path fallback under any ambient env

### DIFF
--- a/tests/test_rustledger_component_marshal.py
+++ b/tests/test_rustledger_component_marshal.py
@@ -42,6 +42,21 @@ def test_wasm_path_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     assert _default_wasm_path() == Path("/somewhere/custom.wasm")
 
 
+def test_wasm_path_without_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The bundled-path fallback must be covered regardless of ambient env.
+
+    rustledger's downstream CI exports ``RUSTLEDGER_COMPONENT_WASM`` for the
+    whole pytest run, which meant this branch never executed there and the
+    100% coverage gate failed on an env quirk rather than a real gap. Delete
+    the variable explicitly so both branches are covered in every
+    environment.
+    """
+    monkeypatch.delenv("RUSTLEDGER_COMPONENT_WASM", raising=False)
+    path = _default_wasm_path()
+    assert path.name == "rustledger_ffi_component.wasm"
+    assert path.parent.name == "rustledger"
+
+
 def test_download_component_writes_file(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## What

Adds the symmetric `monkeypatch.delenv` test for `_default_wasm_path()`'s bundled-path fallback, so both branches are covered **regardless of the ambient `RUSTLEDGER_COMPONENT_WASM`**.

## Why

rustledger's downstream CI (`downstream.yml`, *rustfava tests against PR component*) exports `RUSTLEDGER_COMPONENT_WASM` for the whole pytest run. With the variable set, the fallback line (`component_engine.py:122`) never executes, coverage lands at **99.97%**, and the `--cov-fail-under=100` gate fails — on an environment quirk, not a real gap. That job has been red on this for its entire recent history (0 successes in the last 60 runs), which meant a systemically-red check on every rustledger PR.

The override branch already had a `monkeypatch.setenv` test; the fallback branch was only covered incidentally, by runs where the ambient variable happened to be unset (rustfava's own CI — which is why it stayed green here while downstream burned).

## Testing

- Full `just test-py` at **100.00%** with the env var exported (the exact downstream shape), against a locally built rustledger component — 660 passed.
- File-level ruff check/format and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)