### PR TITLE
test: accept newer component minors in test_version

### DIFF
--- a/tests/test_rustledger_component_engine.py
+++ b/tests/test_rustledger_component_engine.py
@@ -51,8 +51,18 @@ SRC = (
 )
 
 
+# The MINIMUM contract version this rustfava requires. The component may be
+# NEWER: minor bumps are additive by the WIT versioning policy, and
+# rustledger's downstream CI deliberately runs these tests against
+# unreleased PR components — a hard equality here turned every upstream
+# minor bump into a red downstream job (rustledger#1755's 3.4 bump).
+MIN_API_VERSION = (3, 3)
+
+
 def test_version(engine: RustledgerComponentEngine) -> None:
-    assert engine.version() == "3.3"
+    major, minor = (int(p) for p in engine.version().split("."))
+    assert major == MIN_API_VERSION[0], "major bump = breaking contract change"
+    assert minor >= MIN_API_VERSION[1]
 
 
 def test_load_marshals_typed_directives(


### PR DESCRIPTION
Hard `== "3.3"` turned every upstream minor bump into a red downstream job: rustledger's *rustfava tests against PR component* deliberately runs this suite against unreleased components (currently failing on rustledger#1755's 3.4 bump), and minor bumps are additive by the WIT versioning policy. Now asserts major equality (breaking-change guard intact) and minor ≥ `MIN_API_VERSION` — the minimum this rustfava requires.

Verified against both: the pinned 3.3 component (no override) and a locally built 3.4 component (`RUSTLEDGER_COMPONENT_WASM`) — green each way; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)