### PR TITLE
chore: bump rustledger to v0.21.0

### DIFF
--- a/src/rustfava/rustledger/engine.py
+++ b/src/rustfava/rustledger/engine.py
@@ -22,7 +22,7 @@ SUPPORTED_API_MAJOR = 3
 # Rustledger release this build is pinned to. The component wasm
 # (``rustledger-ffi-component-<version>.wasm``) is downloaded lazily from this
 # release by ``component_engine``. Bumped by ``update-rustledger.yml``.
-RUSTLEDGER_VERSION = "v0.20.2"
+RUSTLEDGER_VERSION = "v0.21.0"
 
 
 class RustledgerError(Exception):


### PR DESCRIPTION
Bumps `RUSTLEDGER_VERSION` to **v0.21.0**: two weeks of correctness work (the rustledger#1731–#1743 review series, DisplayContext report rendering) and **WIT 3.4.0's `session.from-entries`** — the prerequisite for #249, which follows on top of this.

Verified: full `just test-py` at **100.00% coverage, 660 passed** against the released `rustledger-ffi-component-v0.21.0.wasm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)