### PR TITLE
feat: adopt session.from-entries for the query path

### DIFF
--- a/src/rustfava/core/query_shell.py
+++ b/src/rustfava/core/query_shell.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import io
 import shlex
 from decimal import Decimal
 from typing import TYPE_CHECKING
@@ -16,17 +15,19 @@ from rustfava.helpers import RustfavaAPIError
 from rustfava.rustledger.query import CompilationError
 from rustfava.rustledger.query import connect
 from rustfava.rustledger.query import ParseError
-from rustfava.rustledger.query import RLConnection
-from rustfava.rustledger.query import RLCursor
+from rustfava.rustledger.query import SessionCache
 from rustfava.util.excel import HAVE_EXCEL
 from rustfava.util.excel import to_csv
 from rustfava.util.excel import to_excel
 
 if TYPE_CHECKING:  # pragma: no cover
+    import io
     from collections.abc import Sequence
 
     from rustfava.beans.abc import Directive
     from rustfava.core import RustfavaLedger
+    from rustfava.rustledger.query import RLConnection
+    from rustfava.rustledger.query import RLCursor
 
 
 class FavaShellError(RustfavaAPIError):
@@ -75,10 +76,13 @@ class FavaQueryRunner:
 
     def __init__(self, ledger: RustfavaLedger) -> None:
         self.ledger = ledger
+        # Held-session cache (#249): one component session per live entry
+        # set, so repeated queries on the same fava filter state skip the
+        # per-query directive marshaling. Lives here because the shell
+        # persists across requests while connections are per-call.
+        self._session_cache = SessionCache()
 
-    def run(
-        self, entries: Sequence[Directive], query: str
-    ) -> RLCursor | str:
+    def run(self, entries: Sequence[Directive], query: str) -> RLCursor | str:
         """Run a query, returning cursor or text result."""
         # Get the source from the ledger for queries
         source = getattr(self.ledger, "_source", None)
@@ -94,6 +98,10 @@ class FavaQueryRunner:
         if source:
             conn.set_source(source)
 
+        session = self._session_cache.get(conn._engine, entries)  # noqa: SLF001
+        if session is not None:
+            conn.set_session(session)
+
         # Parse the query to handle special commands
         query = query.strip()
         query_lower = query.lower()
@@ -103,11 +111,13 @@ class FavaQueryRunner:
         if query_lower in (".exit", ".quit", "exit", "quit"):
             return noop_doc
 
-        # Handle .run or run command
-        if query_lower.startswith((".run", "run")):
-            # Check if it's just "run" or ".run" (list queries) or "run name"
-            if query_lower in ("run", ".run") or query_lower.startswith(("run ", ".run ")):
-                return self._handle_run(query, conn)
+        # Handle .run or run command: just "run"/".run" (list queries)
+        # or "run name"
+        if query_lower.startswith((".run", "run")) and (
+            query_lower in ("run", ".run")
+            or query_lower.startswith(("run ", ".run "))
+        ):
+            return self._handle_run(query, conn)
 
         # Handle help commands - return text
         if query_lower.startswith((".help", "help")):
@@ -240,7 +250,7 @@ class QueryShell(FavaModule):
         rtypes = res.description
 
         # Convert rows to exportable format
-        rows = _numberify_rows(rrows, rtypes)
+        rows = _numberify_rows(rrows)
 
         if result_format == "csv":
             data = to_csv(list(rtypes), rows)
@@ -254,7 +264,6 @@ class QueryShell(FavaModule):
 
 def _numberify_rows(
     rows: list[tuple[object, ...]],
-    columns: tuple[object, ...],
 ) -> list[tuple[object, ...]]:
     """Convert row values to exportable format.
 
@@ -263,20 +272,23 @@ def _numberify_rows(
     result: list[tuple[object, ...]] = []
     for row in rows:
         new_row: list[object] = []
-        for i, value in enumerate(row):
-            col = columns[i]
+        for value in row:
             # Convert complex types to strings for export
             if hasattr(value, "number") and hasattr(value, "currency"):
                 # Amount-like
                 new_row.append(f"{value.number} {value.currency}")
             elif isinstance(value, dict):
-                # Inventory. The cursor layer (query._convert_row_value) is the
-                # single place that interprets the engine's {"positions": [...]}
-                # payload, flattening it to {currency: Decimal} (summing cost
-                # lots). Render that canonical form here as "<number> <currency>"
-                # parts, matching the Amount case above and comma-joining
-                # multi-currency inventories (sorted for stable output).
-                if value and all(isinstance(v, Decimal) for v in value.values()):
+                # Inventory. The cursor layer
+                # (query._convert_row_value) is the single place that
+                # interprets the engine's {"positions": [...]} payload,
+                # flattening it to {currency: Decimal} (summing cost
+                # lots). Render that canonical form here as
+                # "<number> <currency>" parts, matching the Amount case
+                # above and comma-joining multi-currency inventories
+                # (sorted for stable output).
+                if value and all(
+                    isinstance(v, Decimal) for v in value.values()
+                ):
                     new_row.append(
                         ", ".join(
                             f"{number} {currency}"

--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -869,6 +869,29 @@ class RustledgerComponentEngine:
         handle = inst.get_func(store, fidx)(store, source)
         return ComponentSession(self, store, inst, handle)
 
+    def open_session_entries(
+        self, entries_json: list[dict[str, Any]]
+    ) -> ComponentSession:
+        """Hold an already-loaded entry set in a session (WIT >= 3.4.0).
+
+        The entries marshal across the wire ONCE here; subsequent
+        ``session.query`` calls run against directives held inside the
+        component with no per-call shuttling — the missing piece that lets
+        fava's FILTERED entry sets (#249) use sessions at all. Raises on
+        components older than 3.4.0 (no ``from-entries`` export); callers
+        gate/fall back (see ``rustfava.rustledger.query.SessionCache``).
+        """
+        self._ensure_version()
+        store, inst = self._instantiate()
+        fidx = self._component.get_export_index(
+            "[static]session.from-entries", self._iface(_LEDGER)
+        )
+        func = inst.get_func(store, fidx)
+        entries_type = func.type(store).params[0][1]
+        wit_entries = _unmarshal(list(entries_json), entries_type)
+        handle = func(store, wit_entries)
+        return ComponentSession(self, store, inst, handle)
+
     def open_session_file(
         self,
         path: str,

--- a/src/rustfava/rustledger/query.py
+++ b/src/rustfava/rustledger/query.py
@@ -202,6 +202,51 @@ def connect(
     return RLConnection(entries, options)
 
 
+class SessionCache:
+    """One held component session per live entry set (#249).
+
+    fava's query endpoint runs against FILTERED entries; before sessions,
+    every BQL query shipped the full filtered directive list across the
+    wire (``query-entries``) and re-converted it per query. This cache
+    pays that marshaling once per entry set: ``get`` returns a held
+    :class:`ComponentSession` for the SAME entries object (identity — the
+    strong reference kept here guarantees the id stays valid), opening a
+    fresh one when the filter (or the whole ledger, on reload) changes.
+
+    Size one by design: fava views churn between a handful of filter
+    states but query bursts hit one state repeatedly; replacing on change
+    also releases the previous entries list and its session. Engines
+    without ``open_session_entries`` (JSON-RPC) or components without
+    ``from-entries`` (< WIT 3.4.0) disable the cache on first failure and
+    callers fall back to ``query_entries`` permanently.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty cache."""
+        self._entries: Sequence[Directive] | None = None
+        self._session: Any = None
+        self._disabled = False
+
+    def get(self, engine: Any, entries: Sequence[Directive]) -> Any:
+        """A held session for ``entries``, or ``None`` when unavailable."""
+        if self._disabled or not hasattr(engine, "open_session_entries"):
+            return None
+        if self._entries is entries:
+            return self._session
+        try:
+            session = engine.open_session_entries(
+                directives_to_json(list(entries))
+            )
+        except Exception:  # noqa: BLE001 — old component, wire error: fall back
+            self._disabled = True
+            self._entries = None
+            self._session = None
+            return None
+        self._entries = entries
+        self._session = session
+        return session
+
+
 class RLConnection:
     """Connection for executing BQL queries against entries.
 
@@ -220,6 +265,11 @@ class RLConnection:
         self._options = options
         self._engine = get_engine()
         self._source: str | None = None
+        self._session: Any = None
+
+    def set_session(self, session: Any) -> None:
+        """Attach a held component session for wire-free queries (#249)."""
+        self._session = session
 
     def set_source(self, source: str) -> None:
         """Set the source for queries.
@@ -243,7 +293,11 @@ class RLConnection:
             CompilationError: If the query cannot be compiled
             RuntimeError: If source is not set
         """
-        if hasattr(self._engine, "query_entries"):
+        if self._session is not None:
+            # Held session (#249): the entries already live inside the
+            # component — no per-query marshaling at all.
+            result = self._session.query(query_string)
+        elif hasattr(self._engine, "query_entries"):
             # Component engine: query the directive set directly via the typed
             # `query-entries`, so there is no re-render of entries to beancount
             # source (which can produce text the parser rejects).

--- a/tests/test_core_query_shell.py
+++ b/tests/test_core_query_shell.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
@@ -69,10 +68,7 @@ def test_query_balances(
 ) -> None:
     assert isinstance(run_query(".run custom_query"), QueryResultTable)
     bal = run_query("balances")
-    if sys.version_info >= (3, 12):
-        # This fails for some reason on older Pythons, probably some minor
-        # difference there.
-        snapshot(bal)
+    snapshot(bal)
     assert run_query(".run custom_query") == bal
     assert run_query(".run 'custom query with space'") == bal
 
@@ -146,9 +142,7 @@ def test_numberify_rows_renders_inventory_as_amount_strings() -> None:
         ({"ITOT": Decimal(60)},),
         ({"USD": Decimal(5), "EUR": Decimal(3)},),
     ]
-    columns = (object(),)  # single column; branch keys off the value, not col
-
-    out = _numberify_rows(rows, columns)
+    out = _numberify_rows(rows)
 
     assert out[0] == ("502.25 USD",)
     assert out[1] == ("60 ITOT",)

--- a/tests/test_rustledger_component_engine.py
+++ b/tests/test_rustledger_component_engine.py
@@ -388,3 +388,23 @@ def test_missing_wasm_download_fallback_errors(
     )
     with pytest.raises(RustledgerError, match="wasm32-wasip2"):
         component_engine.RustledgerComponentEngine()
+
+
+# ===== session.from-entries (#249, WIT >= 3.4.0) =====
+
+
+def test_open_session_entries_holds_and_queries(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """A held entry set answers queries identically to query-entries."""
+    entries = engine.load(SRC)["entries"]
+    session = engine.open_session_entries(entries)
+    held = session.query("SELECT account, sum(position) GROUP BY account")
+    shipped = engine.query_entries(
+        entries, "SELECT account, sum(position) GROUP BY account"
+    )
+    assert held["errors"] == []
+    assert held["columns"] == shipped["columns"]
+    assert sorted(map(str, held["rows"])) == sorted(map(str, shipped["rows"]))
+    # The session holds ALL the entries it was given.
+    assert len(session.info()["entries"]) == len(entries)

--- a/tests/test_rustledger_query.py
+++ b/tests/test_rustledger_query.py
@@ -22,6 +22,7 @@ from rustfava.rustledger.query import CompilationError
 from rustfava.rustledger.query import connect
 from rustfava.rustledger.query import ParseError
 from rustfava.rustledger.query import RLCursor
+from rustfava.rustledger.query import SessionCache
 from rustfava.rustledger.types import RLCustom
 from rustfava.rustledger.types import RLCustomValue
 from rustfava.rustledger.types import RLOpen
@@ -346,3 +347,74 @@ def test_entries_to_source_skips_entries_that_render_empty(
         postings=[],
     )
     assert _entries_to_source([entry]) == ""
+
+
+# ===== SessionCache (#249) =====
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def query(self, query_string: str) -> dict[str, object]:
+        self.queries.append(query_string)
+        return {"columns": [], "rows": [], "errors": []}
+
+
+class _FakeEngine:
+    """Engine double with open_session_entries; counts opens."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.opens = 0
+        self._fail = fail
+
+    def open_session_entries(self, _entries_json: list) -> _FakeSession:
+        self.opens += 1
+        if self._fail:
+            msg = "no from-entries export"
+            raise RuntimeError(msg)
+        return _FakeSession()
+
+
+class _NoSessionEngine:
+    """Engine double without the capability (JSON-RPC shape)."""
+
+
+def test_session_cache_identity_hit_and_miss() -> None:
+    cache = SessionCache()
+    engine = _FakeEngine()
+    entries_a: list = []
+    entries_b: list = []
+    first = cache.get(engine, entries_a)
+    assert first is not None
+    # Same object: cache hit, no new open.
+    assert cache.get(engine, entries_a) is first
+    assert engine.opens == 1
+    # Different object (filter change / reload): fresh session.
+    second = cache.get(engine, entries_b)
+    assert second is not first
+    assert engine.opens == 2
+
+
+def test_session_cache_disabled_without_capability() -> None:
+    cache = SessionCache()
+    assert cache.get(_NoSessionEngine(), []) is None
+
+
+def test_session_cache_disables_permanently_on_open_failure() -> None:
+    cache = SessionCache()
+    engine = _FakeEngine(fail=True)
+    entries: list = []
+    assert cache.get(engine, entries) is None
+    # Second call must NOT retry the failing open.
+    assert cache.get(engine, entries) is None
+    assert engine.opens == 1
+
+
+def test_connection_prefers_held_session() -> None:
+    conn = connect("rustledger:", entries=[], errors=[], options={})
+    session = _FakeSession()
+    conn.set_session(session)
+    cursor = conn.execute("SELECT account")
+    assert session.queries == ["SELECT account"]
+    assert list(cursor) == []


### PR DESCRIPTION
## What

Implements #249 on top of #252 (the v0.21.0 bump, which this branch includes): BQL queries now run against a **held component session** instead of shipping the full filtered directive list across the wire per query.

## Design (as specced in #249)

- `RustledgerComponentEngine.open_session_entries(entries_json)` binds `[static]session.from-entries` (WIT 3.4.0) — the entries marshal once.
- `SessionCache` lives on the query shell (persists across requests; connections are per-call). Size one, keyed on **entry-set identity** — the cache's strong reference pins the object id, so a hit is sound; a filter change or ledger reload produces a different entries object and rolls the session naturally. No mtime/filter-string bookkeeping needed.
- `RLConnection.execute()` prefers the held session; the `query_entries` fallback remains for JSON-RPC engines and pre-3.4.0 components (capability probe + permanent disable on first open failure — no per-query retry storms).

## Effect

First query per filter state pays one marshal (same as before); every subsequent query on that state is **wire-free** — `session.query` runs against directives held inside the component.

## Testing

- Engine binding: held-session query result == `query_entries` result on the same entries; `info()` confirms all entries held.
- Cache: identity hit (no re-open), miss on new object (fresh session), no-capability gating, permanent disable after open failure.
- Connection fast path drives a fake session.
- Full suite: 663 passed; the two `test_core_watcher` failures are fd-pressure flakes in my sandbox (pass in isolation; unrelated files) — CI is the arbiter.

Merge after #252.

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)