### PR TITLE
test: pin the display-precision fallback's cost/balance/price arms directly

### DIFF
--- a/tests/test_rustledger_loader_plugins.py
+++ b/tests/test_rustledger_loader_plugins.py
@@ -181,6 +181,66 @@ def test_errors_from_json_source_formats() -> None:
     assert source["filename"] == "main.beancount"
 
 
+def test_display_precision_covers_costs_balances_and_prices() -> None:
+    """Cost amounts, balance amounts, and price-directive amounts all feed
+    the precision counts, and repeat observations of a currency accumulate.
+
+    Engines shipping ``display_precision`` (rustledger WIT 3.8+) bypass
+    this fallback entirely, so integration tests no longer reach these
+    arms — they are pinned here directly to keep the fallback correct for
+    engines that predate the field.
+    """
+    precision = _compute_display_precision(
+        [
+            {
+                "type": "transaction",
+                "postings": [
+                    {"units": {"number": "1.25", "currency": "USD"}},
+                    # Second USD observation: accumulates into the existing
+                    # counter rather than creating a new one.
+                    {"units": {"number": "2.5", "currency": "USD"}},
+                    {
+                        "units": {"number": "10", "currency": "GLD"},
+                        "cost": {
+                            "number": {"kind": "per_unit", "value": "1500.12"},
+                            "currency": "USD",
+                        },
+                    },
+                    {
+                        "units": {"number": "1", "currency": "GLD"},
+                        "cost": {
+                            "number": {"kind": "total", "value": "999.1234"},
+                            "currency": "CAD",
+                        },
+                    },
+                    {
+                        "units": {"number": "2", "currency": "GLD"},
+                        # Cost present but without a number: tracked nothing.
+                        "cost": {"currency": "CAD"},
+                    },
+                ],
+            },
+            {
+                "type": "balance",
+                "amount": {"number": "100.500", "currency": "EUR"},
+            },
+            {"type": "price", "amount": {"number": "7.25", "currency": "CHF"}},
+            # Neither transaction nor balance/price: contributes nothing.
+            {"type": "open", "account": "Assets:Cash"},
+        ]
+    )
+    assert precision == {
+        # Mode of {2dp: "1.25", 1dp: "2.5"} plus the 2dp per-unit cost.
+        "USD": 2,
+        "GLD": 0,
+        # The total-shaped cost number feeds the cost currency.
+        "CAD": 4,
+        # Balance and price-directive amounts.
+        "EUR": 3,
+        "CHF": 2,
+    }
+
+
 def test_display_precision_currency_without_samples() -> None:
     """A currency tracked but with no countable precisions is skipped."""
     assert (
@@ -228,6 +288,7 @@ def test_load_uncached_keeps_ffi_display_precision(
 ) -> None:
     """load_uncached has its own copy of the precision workaround; the
     FFI-provided branch is engine-version-gated like load_string's."""
+
     class StubEngine:
         @staticmethod
         def load_full(*_args: Any, **_kwargs: Any) -> dict[str, Any]:


### PR DESCRIPTION
rustledger WIT 3.8+ engines ship `options.display_precision` (rustledger#1766, implemented in rustledger#1808) — the "planned FFI field" the fallback's guard comment anticipates. Against such a component, integration tests no longer reach `_compute_display_precision`'s cost/balance/price tracking arms, and the 100% coverage gate trips in rustledger's downstream `rustfava tests against PR component` job.

This pins those arms with a direct unit test (cost per-unit and total shapes, number-less cost, balance and price-directive amounts, repeat-currency accumulation, and a non-tracked entry type), so the fallback stays covered and correct for engines that predate the field — regardless of which engine the suite runs against.

Verified locally: full suite at 100.00% coverage and 666 passed against the rustledger#1808 debug component.

Once rustfava requires a 3.8+ engine, the fallback (and this test) can be deleted outright — the engine-provided field supersedes it, and the local re-derivation has known drift from the canonical inference (per-unit-first cost sampling where rustledger core samples total-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gJH7uBBF9Xw9et9QFRcsU