### PR TITLE
test: drop the interpolation error rledger no longer raises

### DIFF
--- a/tests/__snapshots__/test_json_api-test_api_errors
+++ b/tests/__snapshots__/test_json_api-test_api_errors
@@ -6,10 +6,4 @@
              'not enough to reduce (2020-01-01, "sell")',
   'source': {'filename': 'TEST_DATA_DIR/errors.beancount',
              'lineno': 0},
-  'type': 'BeancountError'},
- {'message': 'interpolation failed: multiple postings missing amounts or with '
-             'unresolved cost specs for currency USD (2 unknowns) (2018-07-07, '
-             '"b")',
-  'source': {'filename': 'TEST_DATA_DIR/errors.beancount',
-             'lineno': 0},
   'type': 'BeancountError'}]


### PR DESCRIPTION
Companion to rustledger/rustledger#1921 (issue rustledger/rustledger#1920). Snapshot only, no rustfava code changes.

## Why

`tests/data/errors.beancount` contains:

```beancount
2018-07-07 * "a" "b"
  Assets:Cash     -14.00 USD
  Expenses:Stuff    4.14
  Expenses:Stuff
```

rledger rejected it with `multiple postings missing amounts or with unresolved cost specs for currency USD (2 unknowns)`, and the snapshot pinned that.

`4.14` is a number with the **currency** elided, not a posting to be solved. rledger was routing it down the same path as the fully-elided posting below it, so it counted two unknowns where there is one, and in other ledgers it went further and *overwrote* the number with whatever balanced the books.

It now infers only the currency and keeps the number:

```
Assets:Cash     -14.00 USD
Expenses:Stuff    4.14 USD
Expenses:Stuff    9.86 USD
```

which is byte-for-byte what Python beancount produces for the same input:

```
$ python -c "from beancount import loader; ..."
Assets:Cash -14.00 USD
Expenses:Stuff 4.14 USD
Expenses:Stuff 9.86 USD
```

## What changed

One entry removed from `tests/__snapshots__/test_json_api-test_api_errors`. The other two (`No operating currency specified`, `Not enough units in Assets:Stock`) are untouched, and the file stays sorted by message.

Regenerated from the fixed rledger rather than hand-edited, and verified against beancount.

**Merge order:** this should land with or after rustledger/rustledger#1921, since the snapshot describes the fixed behaviour.
