### PR TITLE
fix: refuse an ambiguous entry hash instead of picking a winner

### DIFF
--- a/src/rustfava/core/__init__.py
+++ b/src/rustfava/core/__init__.py
@@ -22,9 +22,7 @@ from rustfava.beans.funcs import hash_entry
 from rustfava.beans.helpers import slice_entry_dates
 from rustfava.beans.load import load_uncached
 from rustfava.beans.prices import RustfavaPriceMap
-from rustfava.beans.str import to_string
 from rustfava.core.accounts import AccountDict
-from rustfava.rustledger import is_encrypted_file
 from rustfava.core.attributes import AttributesModule
 from rustfava.core.budgets import BudgetModule
 from rustfava.core.charts import ChartModule
@@ -47,6 +45,7 @@ from rustfava.core.tree import Tree
 from rustfava.core.watcher import Watcher
 from rustfava.core.watcher import WatchfilesWatcher
 from rustfava.helpers import RustfavaAPIError
+from rustfava.rustledger import is_encrypted_file
 from rustfava.util import listify
 from rustfava.util.date import dateranges
 
@@ -73,6 +72,19 @@ class EntryNotFoundForHashError(RustfavaAPIError):
 
     def __init__(self, entry_hash: str) -> None:
         super().__init__(f'No entry found for hash "{entry_hash}"')
+
+
+class AmbiguousEntryHashError(RustfavaAPIError):
+    """More than one entry has this hash."""
+
+    def __init__(self, entry_hash: str, count: int) -> None:
+        super().__init__(
+            f'{count} entries share the hash "{entry_hash}", so this '
+            f"operation cannot tell which one you meant. Two directives "
+            f"that are identical in every field rustledger hashes will "
+            f"collide; adding a metadata key to one of them makes them "
+            f"distinct."
+        )
 
 
 class StatementNotFoundError(RustfavaAPIError):
@@ -614,7 +626,20 @@ class RustfavaLedger:
                 )
 
     def _get_entry(self, entry_hash: str) -> Directive:
-        """Find an entry.
+        """Find the one entry with this hash.
+
+        The hash is not a label — it is a write address. Callers resolve an
+        entry through it and then mutate that entry's line in the source file
+        (``save_entry_slice``, ``delete_entry_slice``, ``insert_metadata``), so
+        resolving to the wrong entry edits the wrong part of the user's ledger.
+
+        This used to be ``next(...)``: the first match won and the docstring
+        asserted the result was "the (unique) entry" without anything checking
+        it. Nothing guarantees uniqueness — two transactions identical in date,
+        narration and postings hash the same, and duplicates like that occur in
+        real ledgers. Refusing an ambiguous hash turns a silent wrong-target
+        edit into a visible error, which is the difference between losing data
+        and being told to disambiguate.
 
         Arguments:
             entry_hash: Hash of the entry.
@@ -624,15 +649,20 @@ class RustfavaLedger:
 
         Raises:
             EntryNotFoundForHashError: If there is no entry for the given hash.
+            AmbiguousEntryHashError: If more than one entry has that hash.
         """
-        try:
-            return next(
-                entry
-                for entry in self.all_entries
-                if entry_hash == hash_entry(entry)
-            )
-        except StopIteration as exc:
-            raise EntryNotFoundForHashError(entry_hash) from exc
+        # Deliberately NOT short-circuiting on the first match: knowing whether
+        # the hash is ambiguous requires looking at all of them.
+        matches = [
+            entry
+            for entry in self.all_entries
+            if entry_hash == hash_entry(entry)
+        ]
+        if not matches:
+            raise EntryNotFoundForHashError(entry_hash)
+        if len(matches) > 1:
+            raise AmbiguousEntryHashError(entry_hash, len(matches))
+        return matches[0]
 
     def context(
         self,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from rustfava.beans.funcs import hash_entry
+from rustfava.core import AmbiguousEntryHashError
 from rustfava.core import EntryNotFoundForHashError
 from rustfava.core import FilteredLedger
 from rustfava.helpers import RustfavaAPIError
@@ -63,6 +64,41 @@ def test_ledger_get_entry(
 
     with pytest.raises(EntryNotFoundForHashError):
         small_example_ledger.get_entry("asdfa")
+
+
+def test_ledger_get_entry_refuses_an_ambiguous_hash(
+    small_example_ledger: RustfavaLedger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ambiguous hash must raise, not silently resolve to the first match.
+
+    ``get_entry`` is how every mutating endpoint finds the line it is about to
+    rewrite or delete, so picking a winner among several candidates edits the
+    wrong part of the user's ledger with no indication anything went wrong.
+
+    Nothing guarantees hashes are unique: two transactions identical in every
+    hashed field collide, and duplicates like that are ordinary in real
+    ledgers. The duplicate here is the *same object* listed twice, which is the
+    strongest form of the case — no hash function of directive content can
+    tell those apart, so this cannot be fixed by hashing more fields.
+    """
+    first = small_example_ledger.all_entries[0]
+    entries = [first, *small_example_ledger.all_entries, first]
+    monkeypatch.setattr(small_example_ledger, "all_entries", entries)
+    # `get_entry` is an `lru_cache` over `_get_entry` and the ledger fixture is
+    # shared, so without this the lookup is answered from a neighbouring test's
+    # cached result and never reaches the code under test. (Production clears
+    # the same cache in `changed()`.)
+    small_example_ledger.get_entry.cache_clear()
+
+    with pytest.raises(AmbiguousEntryHashError) as exception:
+        small_example_ledger.get_entry(hash_entry(first))
+
+    message = str(exception.value)
+    assert "3 entries share the hash" in message, message
+    # The message has to say what to DO about it — an error that only reports
+    # a dead end sends the user back to the same click.
+    assert "metadata" in message, message
 
 
 def test_paths_to_watch(


### PR DESCRIPTION
The consumer half of rustledger#1968. Pairs with rustledger#1984, but stands
alone — it is a fix regardless of what that hash contains.

## The bug

`get_entry` is how **every mutating endpoint** finds the line it is about to
rewrite or delete: `save_entry_slice`, `delete_entry_slice`, `insert_metadata`.
It was:

```python
next(e for e in self.all_entries if entry_hash == hash_entry(e))
```

First match wins — and the docstring above it asserted the result was "the
**(unique)** entry" without anything checking that.

Nothing guarantees uniqueness. Two transactions identical in every field
rustledger hashes collide, and duplicates like that are ordinary in real ledgers
(two identical coffees on the same day). When it happens, the UI edits a
*different* transaction than the one the user clicked, with no indication
anything went wrong.

Two of the three mutating paths carry a second factor — the sha256sum of the
displayed source slice — so they fail with "changed externally" rather than
corrupting anything. **`insert_metadata` carries none**, and it is the endpoint
most likely to be operating on entries that differ only by metadata.

## The fix

Collect all matches; raise `AmbiguousEntryHashError` on more than one. A silent
wrong-target edit becomes a visible error.

Deliberately **not** short-circuiting — knowing whether a hash is ambiguous means
looking at every entry, so this is O(n) where it used to average less.
`hash_entry` is a dict lookup on rustledger entries, so that's microseconds even
on a large ledger, and the alternative is being fast at editing the wrong line.

The message names the **remedy**, not just the dead end: adding a metadata key to
one of the two makes them distinct (true as of rustledger#1984). An error that
only tells the user they're stuck sends them back to the same click.

## Verification

Sabotage-verified twice — restoring first-match-wins fails the test, and so does
dropping the remedy from the message.

The test duplicates the **same object** rather than constructing a lookalike,
which is the strongest form of the case: no hash function over directive content
can tell those apart, so it can't be papered over by hashing more fields.

Full suite: 665 passed, 1 skipped. The two locale failures
(`test_get_translations`, `test_fava_options_language`) reproduce identically on
pristine `origin/main` — no compiled `.mo` files when running from `src/`.

Two incidental fixes in the same file, both pre-existing and both flagged by ruff
only because this commit touches it: an unused `to_string` import (verified
nothing imports it from `rustfava.core`) and an out-of-order `is_encrypted_file`
import.
