### PR TITLE
docs: correct what _WIT_VERSION does, and pin it to the release it describes

### DIFF
--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -52,11 +52,40 @@ from rustfava.rustledger.engine import _check_api_version
 from rustfava.rustledger.engine import RUSTLEDGER_VERSION
 from rustfava.rustledger.engine import RustledgerError
 
-# The exported WIT interfaces of package ``rustledger:ledger``. The interface
-# IDs embed the full WIT package version (independent of the rustledger release
-# version), so a WIT bump means updating ``_WIT_VERSION`` here — a mismatch
-# makes ``get_export_index`` return ``None`` and every call fail.
-_WIT_VERSION = "3.3.0"
+# The WIT interfaces of package ``rustledger:ledger``. This version string is
+# used two ways: to build the interface IDs passed to ``get_export_index``, and
+# to name the ``host`` instance registered on the linker below.
+#
+# Matching is by MAJOR, not by exact version. Measured against the pinned
+# v0.21.0 component, which exports ``@3.4.0``:
+#
+#     pin 3.0.0 / 3.3.0 / 3.4.0 / 3.5.0 / 3.11.0
+#         -> instantiates, version() = 3.4
+#     pin 2.4.0 / 4.0.0
+#         -> WasmtimeError
+#
+# Either direction works within a major; only a different major fails. Note
+# where it fails — at instantiation, on the IMPORT side ("component imports
+# instance ``rustledger:ledger/host@3.4.0``, but a match ..."), because
+# ``_HOST`` below names the instance the linker offers -- not on export
+# lookup, which is where the old note pointed.
+#
+# So a MINOR bump does not require touching this, and the previous note here —
+# that a mismatch "makes ``get_export_index`` return ``None`` and every call
+# fail" — was wrong: this file has been pinned to 3.3.0 against a 3.4.0
+# component for as long as v0.21.0 has been pinned, and works.
+#
+# What a bump can genuinely break is a new MANDATORY IMPORT, which no version
+# string reveals: WIT 3.1 -> 3.2 added ``host.decrypt`` and made the component
+# un-instantiable until the linker grew the binding (the #218 incident).
+# ``update-rustledger.yml`` therefore holds ANY WIT change for human review,
+# and the question to answer is "what does the component import that
+# ``_define_host_interface`` does not define" — inspect it with
+# ``wasm-tools component wit``, not by comparing this constant.
+#
+# Kept in step with the pinned release anyway, as documentation of what the
+# bindings were written against.
+_WIT_VERSION = "3.4.0"
 _LEDGER = f"rustledger:ledger/ledger@{_WIT_VERSION}"
 _BUILDER = f"rustledger:ledger/builder@{_WIT_VERSION}"
 _UTIL = f"rustledger:ledger/util@{_WIT_VERSION}"


### PR DESCRIPTION
The note on `_WIT_VERSION` said a mismatch

> makes `get_export_index` return `None` and every call fail

It doesn't, and **this file was its own counter-example**: `_WIT_VERSION` has been
`"3.3.0"` while the pinned v0.21.0 component exports `@3.4.0`, and it works —
`version()` returns `3.4`.

## Measured, not reasoned about

Against that component:

| pin | result |
|---|---|
| `3.0.0`, `3.3.0`, `3.4.0`, `3.5.0`, `3.11.0` | instantiates, `version()` = 3.4 |
| `2.4.0`, `4.0.0` | `WasmtimeError` |

Matching is by **major**, in either direction; only a different major fails. And
it fails on the **import** side at instantiation —

```
component imports instance `rustledger:ledger/host@3.4.0`, but a match ...
```

— because `_HOST` names the instance the linker offers. Not on export lookup,
which is where the old note pointed.

## Why this is worth more than tidiness

The comment made the version string look load-bearing for every bump, which sends
a reviewer to check the wrong thing. A minor bump doesn't require touching it.

What a bump *can* genuinely break is a **new mandatory import**, which no version
string reveals: WIT 3.1 → 3.2 added `host.decrypt` and made the component
un-instantiable until the linker grew the binding (#218). `update-rustledger.yml`
already holds any WIT change for human review — the question that review has to
answer is *"what does the component import that `_define_host_interface` doesn't
define"*, answered with `wasm-tools component wit`, not by comparing this
constant.

Concretely: rustledger main is on WIT `3.11.0` against this repo's `3.4.0`, which
looks alarming under the old comment. Both import only `host`, and `host` has the
same single `decrypt` function in both — so the gate will fire on that jump, but
the hazard it exists to catch isn't present.

## Also

Sets the constant to `3.4.0`, what the pinned release actually ships.
Behaviour-neutral per the table above; it removes the puzzle of why the two
disagree and matches what the update workflow would have written.

Component-engine tests: 108 passed. Full suite unchanged at 665 passed / 1
skipped (the two locale failures reproduce on pristine `main` — no compiled
`.mo` files when running from `src/`).
