### PR TITLE
ci: build the docs, strictly, and fix what that surfaced

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,6 +159,31 @@ jobs:
       - run: touch src/rustfava/static/app.js
       - run: just mypy
 
+  docs:
+    # Nothing built the docs before this. `pymdown-extensions` and the rest of
+    # the `docs` group could be bumped, and the site could break, with every
+    # check green — which is how three dead links and a griffe warning
+    # accumulated unnoticed. Runs `just docs`, the same command a developer
+    # runs, so the two cannot drift.
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      # mkdocstrings imports the package to read its docstrings, and the build
+      # step that produces this asset has not run here.
+      - run: touch src/rustfava/static/app.js
+      - run: just docs
+
   check-lockfile:
     runs-on: "ubuntu-latest"
     timeout-minutes: 5

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,8 +5,8 @@ There are several ways to deploy rustfava depending on your needs.
 ## Engine
 
 rustfava runs the rustledger engine as a WebAssembly component in-process via
-the `wasmtime` Python package, which is installed automatically as a
-dependency. Nothing extra to set up.
+the `wasmtime` Python package, which is installed automatically as a dependency.
+Nothing extra to set up.
 
 > The legacy JSON-RPC engine (which shelled out to the `wasmtime` CLI) was
 > removed in rustfava 1.31 after its embedding surface was retired upstream;
@@ -14,7 +14,9 @@ dependency. Nothing extra to set up.
 
 ## Desktop App
 
-For personal use, the [desktop app](https://github.com/rustledger/rustfava/releases) is the simplest option. It runs entirely locally with no server setup required.
+For personal use, the
+[desktop app](https://github.com/rustledger/rustfava/releases) is the simplest
+option. It runs entirely locally with no server setup required.
 
 ## Docker
 
@@ -24,7 +26,9 @@ For server deployments, Docker is recommended:
 docker run -p 5000:5000 -v /path/to/ledger:/data ghcr.io/rustledger/rustfava /data/main.beancount
 ```
 
-For advanced Docker configurations (authentication, HTTPS, docker-compose), see the [Docker deployment guide](../contrib/docker/README.md).
+For advanced Docker configurations (authentication, HTTPS, docker-compose), see
+the
+[Docker deployment guide](https://github.com/rustledger/rustfava/blob/main/contrib/docker/README.md).
 
 ## Systemd Service
 
@@ -95,8 +99,9 @@ Caddy automatically handles HTTPS with Let's Encrypt.
 When exposing rustfava to the internet:
 
 1. **Use HTTPS** - Never expose plain HTTP to the public internet
-2. **Add authentication** - Use a reverse proxy with OAuth2 or basic auth
-3. **Restrict access** - Use firewall rules to limit access to trusted IPs
-4. **Keep updated** - Regularly update rustfava for security patches
+1. **Add authentication** - Use a reverse proxy with OAuth2 or basic auth
+1. **Restrict access** - Use firewall rules to limit access to trusted IPs
+1. **Keep updated** - Regularly update rustfava for security patches
 
-See [SECURITY.md](../SECURITY.md) for more security best practices.
+See [SECURITY.md](https://github.com/rustledger/rustfava/blob/main/SECURITY.md)
+for more security best practices.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,7 +1,8 @@
 # Getting Started
 
 If you're new to Beancount-format files or double-entry accounting in general,
-we recommend [Command-line Accounting in Context](https://docs.google.com/document/d/1e4Vz3wZB_8-ZcAwIFde8X5CjzKshE4-OXtVVHm4RQ8s/),
+we recommend
+[Command-line Accounting in Context](https://docs.google.com/document/d/1e4Vz3wZB_8-ZcAwIFde8X5CjzKshE4-OXtVVHm4RQ8s/),
 a motivational document written by Martin Blais, the creator of the Beancount
 format.
 
@@ -15,15 +16,17 @@ page.
 
 ### Option 1: Desktop App (Recommended)
 
-Download the desktop app from [GitHub Releases](https://github.com/rustledger/rustfava/releases):
+Download the desktop app from
+[GitHub Releases](https://github.com/rustledger/rustfava/releases):
 
-| Platform | Download |
-|----------|----------|
-| **macOS** | `rustfava_x.x.x_aarch64.dmg` |
-| **Windows** | `rustfava_x.x.x_x64-setup.exe` |
-| **Linux** | `rustfava_x.x.x_amd64.AppImage` |
+| Platform    | Download                        |
+| ----------- | ------------------------------- |
+| **macOS**   | `rustfava_x.x.x_aarch64.dmg`    |
+| **Windows** | `rustfava_x.x.x_x64-setup.exe`  |
+| **Linux**   | `rustfava_x.x.x_amd64.AppImage` |
 
-Double-click to launch, then open your `.beancount` file. No Python or other dependencies required.
+Double-click to launch, then open your `.beancount` file. No Python or other
+dependencies required.
 
 ### Option 2: Command Line (PyPI)
 
@@ -65,15 +68,17 @@ uv tool install rustfava[ingest]
 docker run -p 5000:5000 -v /path/to/ledger:/data ghcr.io/rustledger/rustfava /data/main.beancount
 ```
 
-See [Docker deployment](../contrib/docker/README.md) for advanced options.
+See
+[Docker deployment](https://github.com/rustledger/rustfava/blob/main/contrib/docker/README.md)
+for advanced options.
 
 ## Starting rustfava
 
 ### Desktop App
 
 1. Launch the app
-2. Click "Open File" or use File → Open
-3. Select your `.beancount` file
+1. Click "Open File" or use File → Open
+1. Select your `.beancount` file
 
 ### Command Line
 

--- a/justfile
+++ b/justfile
@@ -182,9 +182,15 @@ mypy:
 # ============================================================================
 
 # Build documentation website
+#
+# `--strict` turns mkdocs warnings into failures: a dead cross-reference or an
+# unparseable docstring is a broken page, and without it the build reports the
+# problem and exits 0. Kept here rather than only in CI so the two run the same
+# command — three dead links and a griffe warning had accumulated precisely
+# because nothing was failing on them.
 [group('docs')]
 docs:
-    uv run --no-dev --group docs mkdocs build -d build/docs
+    uv run --no-dev --group docs mkdocs build --strict -d build/docs
 
 # Generate BQL grammar JSON
 [group('docs')]

--- a/src/rustfava/core/query_shell.py
+++ b/src/rustfava/core/query_shell.py
@@ -226,7 +226,7 @@ class QueryShell(FavaModule):
 
         Raises:
             RustfavaAPIError: If the result format is not supported or the
-            query failed.
+                query failed.
         """
         name = "query_result"
 


### PR DESCRIPTION
Nothing built the documentation. `pymdown-extensions` and the rest of the `docs`
group could be bumped, and the site could break, with every check green — which
is how four problems accumulated unnoticed:

| | |
|---|---|
| `docs/usage.md` | dead link to `../contrib/docker/README.md` |
| `docs/deployment.md` | dead link to `../contrib/docker/README.md` |
| `docs/deployment.md` | dead link to `../SECURITY.md` |
| `query_shell.py:229` | griffe could not parse the `Raises` block |

Found while verifying #278 (a `pymdown-extensions` 10 → 11 major), where the
absence of a docs build meant the green checks said nothing about it.

## The fixes

Both link targets **exist** — they are just outside `docs/`, so mkdocs cannot
resolve them as pages. Relinked to their canonical GitHub URLs, which is what
`development.md` already does for `LICENSE`.

The griffe warning was a continuation line that wasn't indented, so
`query failed.` read as a new entry rather than the rest of the description
above it.

## `--strict` is what makes it a gate

Measured, on a reintroduced dead link:

| | exit |
|---|---|
| with `--strict` | **1** |
| without `--strict` | **0**, warning printed |

A build that reports a broken page and exits 0 is exactly why these survived. The
flag goes in the `just docs` recipe rather than only in the workflow, so a
developer and CI run the same command and can't drift — the job is `just docs`,
the same way the mypy job is `just mypy`.

## Verification

| sabotage | result |
|---|---|
| reintroduce a dead link | `just docs` exits 1 |
| un-indent the `Raises` continuation | `just docs` exits 1 |
| restored tree | exit 0, **0 warnings** |

Also re-verified after `mdformat` reflowed the edited prose — the strict build is
still clean at 0 warnings, and the links survived rewrapping.

The docstring edit is comment-only; `query_shell` tests pass (7).
