### PR TITLE
fix: map guest paths on document payloads and diagnostics

### DIFF
--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -796,20 +796,54 @@ class RustledgerComponentEngine:
 
     @staticmethod
     def _rewrite_guest_paths(result: dict[str, Any], host_dir: Path) -> None:
-        """Rewrite ``/work/...`` guest paths in a load result to host paths."""
+        """Rewrite ``/work/...`` guest paths in a load result to host paths.
+
+        Three kinds of path cross this boundary, and all three must be mapped:
+
+        1. ``meta.filename`` — where a directive was *written*.
+        2. A ``document`` directive's ``path`` — the file it *points at*. This
+           is a second, independent path, and it is the only one that matters
+           for documents found by discovery rather than written by hand: those
+           are synthesized, so their ``meta.filename`` is ``<unknown>`` and
+           mapping only ``meta`` is a no-op for them. Leaving it guest-side
+           made every auto-discovered document unreachable — ``statement_path``
+           matches a resolved host path against ``Document.filename`` and can
+           never hit, and ``/document/`` then hands ``send_file`` a path that
+           does not exist on the host (rustfava #277).
+        3. Guest paths *embedded in* diagnostic messages, which are rendered in
+           the UI. These are substrings, not whole fields, so they
+           are relocated by prefix rather than parsed out — a document
+           path may contain spaces, so there is no reliable way to find
+           where one ends.
+        """
+        guest_root = "/work/"
 
         def to_host(p: Any) -> Any:
-            if isinstance(p, str) and p.startswith("/work/"):
-                return str(host_dir / p[len("/work/") :])
+            if isinstance(p, str) and p.startswith(guest_root):
+                return str(host_dir / p[len(guest_root) :])
             return p
+
+        def to_host_embedded(s: Any) -> Any:
+            if isinstance(s, str) and guest_root in s:
+                return s.replace(guest_root, f"{host_dir}{os.sep}")
+            return s
 
         for entry in result.get("entries", []):
             meta = entry.get("meta")
             if isinstance(meta, dict) and "filename" in meta:
                 meta["filename"] = to_host(meta["filename"])
+            # `path` is unique to `document-dir` among output directives, but
+            # gate on the type anyway so a future directive that gains a `path`
+            # meaning something other than a host file is not silently
+            # rewritten.
+            if entry.get("type") == "document" and "path" in entry:
+                entry["path"] = to_host(entry["path"])
         for include in result.get("includes", []):
             if isinstance(include, dict) and "path" in include:
                 include["path"] = to_host(include["path"])
+        for error in result.get("errors", []):
+            if isinstance(error, dict) and "message" in error:
+                error["message"] = to_host_embedded(error["message"])
 
     def clamp_entries(
         self,

--- a/tests/test_rustledger_component_engine.py
+++ b/tests/test_rustledger_component_engine.py
@@ -269,6 +269,44 @@ def test_load_full_returns_host_paths(
     assert not any(f.startswith("/work") for f in filenames)
 
 
+def test_load_full_discovered_document_path_is_on_the_host(
+    engine: RustledgerComponentEngine,
+    tmp_path: Path,
+) -> None:
+    """A document found by discovery points at a file that exists on disk.
+
+    Regression for #277. Discovery synthesizes these entries, so they carry no
+    source location — ``meta.filename`` is ``<unknown>`` — and the only real
+    path on them is the payload ``path``. While that was left as a
+    ``/work/...`` guest path, every auto-discovered document was
+    unreachable: ``/statement/`` matches a resolved host path against
+    ``Document.filename`` and could never
+    hit, and ``/document/`` handed ``send_file`` a path with no host file
+    behind it. Hand-written ``document`` directives were unaffected, which is
+    what hid this — their paths never transit the sandbox.
+
+    The filename deliberately contains a space, because the diagnostic-message
+    rewrite cannot delimit a path by whitespace.
+    """
+    docs = tmp_path / "docs" / "Expenses" / "Foo"
+    docs.mkdir(parents=True)
+    document = docs / "2026-07-07 spaced name.pdf"
+    document.write_text("dummy")
+    main = tmp_path / "main.bean"
+    main.write_text(
+        'option "documents" "docs"\n\n2020-01-01 open Expenses:Foo\n'
+    )
+
+    result = engine.load_full(str(main))
+    documents = [e for e in result["entries"] if e["type"] == "document"]
+    assert len(documents) == 1, "expected discovery to synthesize one document"
+
+    found = documents[0]["path"]
+    assert not found.startswith("/work"), f"guest path leaked: {found}"
+    assert Path(found) == document
+    assert Path(found).exists(), "the mapped path must exist on the host"
+
+
 def test_custom_typed_values_use_jsonrpc_shape(
     engine: RustledgerComponentEngine,
 ) -> None:

--- a/tests/test_rustledger_component_marshal.py
+++ b/tests/test_rustledger_component_marshal.py
@@ -8,6 +8,7 @@ exercise the pure helpers and error/edge branches that the integration tests
 
 from __future__ import annotations
 
+import os
 import urllib.request
 from decimal import Decimal
 from pathlib import Path
@@ -323,6 +324,61 @@ def test_rewrite_guest_paths_edge_shapes() -> None:
         Path("/host") / "inc.beancount"
     )
     assert result["includes"][1] == {"other": "shape"}
+
+
+def test_rewrite_guest_paths_document_payload_and_messages() -> None:
+    """A document's payload path and diagnostic messages are mapped too.
+
+    Regression for #277. ``meta.filename`` is where a directive was *written*;
+    a ``document`` directive's ``path`` is the file it *points at*, and those
+    are independent. Documents found by discovery are synthesized, so they have
+    no source location at all — mapping only ``meta`` is a complete no-op for
+    exactly the entries whose payload path matters, which is why every
+    auto-discovered document was left pointing into the sandbox.
+    """
+    result: dict[str, Any] = {
+        "entries": [
+            # The shape that broke: synthesized by discovery, so
+            # `meta.filename` carries no location, only `path` is real.
+            {
+                "type": "document",
+                "meta": {"filename": "<unknown>"},
+                "path": "/work/docs/Expenses/Foo/2026-07-07 spaced name.pdf",
+            },
+            # A non-document that happens to carry `path` must be left alone.
+            {
+                "type": "custom",
+                "meta": {"filename": "/work/main.beancount"},
+                "path": "/work/not-a-host-file",
+            },
+            {"type": "document", "meta": {}},  # document with no path
+        ],
+        "errors": [
+            {"message": "skipped: /work/docs/Invoices/x y.pdf"},
+            {"message": "nothing to map here"},
+            {"severity": "warning"},  # no message
+        ],
+    }
+    RustledgerComponentEngine._rewrite_guest_paths(result, Path("/host"))
+
+    # Path arithmetic mirrors the implementation so this holds on Windows too.
+    assert result["entries"][0]["path"] == str(
+        Path("/host") / "docs/Expenses/Foo/2026-07-07 spaced name.pdf"
+    )
+    assert result["entries"][1]["meta"]["filename"] == str(
+        Path("/host") / "main.beancount"
+    )
+    # The type gate: `path` is unique to documents today, but a future
+    # directive gaining a `path` that is not a host file must not be rewritten.
+    assert result["entries"][1]["path"] == "/work/not-a-host-file"
+
+    # Messages embed paths mid-string, and a document name may contain spaces,
+    # so the mount prefix is relocated rather than the path parsed out.
+    assert result["errors"][0]["message"] == (
+        f"skipped: {Path('/host')}{os.sep}docs/Invoices/x y.pdf"
+    )
+    assert result["errors"][1]["message"] == "nothing to map here"
+    assert result["errors"][2] == {"severity": "warning"}
 
 
 def test_clamp_accepts_mutated_edge_json(


### PR DESCRIPTION
Closes #277.

## The bug

`_rewrite_guest_paths` mapped `meta.filename` and the include list. But a `document` directive has a **second, independent path** — the file it *points at* — and that one was never mapped.

For entries produced by discovery the rewriter was a complete no-op: they are synthesized, so they carry no source location at all (`meta.filename` is `<unknown>`), and the only real path on them is exactly the one being skipped.

Every auto-discovered document was therefore unreachable:

- **`statement_path`** resolves a transaction's `document:` value to an absolute host path, then looks for a `Document` whose filename equals it. A `/work/…` filename can never match, so `/statement/` always raised `StatementNotFoundError`.
- **`/document/`** is gated on the same values, and `send_file` was handed a path with no host file behind it.

Hand-written `document` directives were unaffected — rledger stores directive filenames verbatim and they never transit the sandbox. That's what isolated the failure to discovery, and what hid it.

Reported on Windows; I reproduced it on Linux, so nothing about it is platform-specific.

## Fix

Rewrite the document payload path, and guest paths embedded in diagnostic messages (surfaced in the UI):

```
before  Document.filename: /work/docs/Expenses/Foo/2026-07-07 account-shaped.pdf
after   Document.filename: /…/probe/docs/Expenses/Foo/2026-07-07 account-shaped.pdf   (exists: True)
```

Two details worth flagging:

- **The wire key is `path`, not `filename`.** `filename` is the attribute name on the typed `Document`; the raw result dict uses `path`. The issue said "payload `filename`", which is right about the object and wrong about the key.
- **Messages are relocated by prefix, not parsed.** A path inside a message is a substring with no delimiter, and a document filename may contain spaces — so there's no reliable way to find where one ends. Replacing the mount prefix sidesteps that entirely. The end-to-end test deliberately uses a filename with a space in it.

Gated on the directive type even though `path` is unique to `document-dir` among output directives today, so a future directive that gains a `path` meaning something other than a host file isn't silently rewritten.

## Tests

Two tests — one on the raw shapes, one end-to-end through a real component asserting the mapped path actually exists on disk.

Sabotage-checked, each failure direction landing on a distinct assertion:

| sabotage | fails |
|---|---|
| drop the document payload rewrite | unit **and** end-to-end |
| drop the message rewrite | the message assertion only |
| remove the type gate | the non-document `path` case only |

Full suite against the pinned `v0.21.0` asset: **669 passed, 1 skipped** (667 before, +2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGRsKA42peqSnz4VMreBG
