### PR TITLE
fix(ci): render the bot's PR body accurately

### DIFF
--- a/.github/workflows/update-rustledger.yml
+++ b/.github/workflows/update-rustledger.yml
@@ -55,9 +55,15 @@ jobs:
           curl -fsSL -o component.wasm.sha256 "${BASE}/${ASSET}.sha256"
           echo "$(cut -d' ' -f1 component.wasm.sha256)  component.wasm" | sha256sum -c -
 
-          # Vendor the verified component (the previous bot only edited the
-          # version string and left the vendored artifact stale — see #219/#220).
-          cp component.wasm src/rustfava/rustledger/rustledger_ffi_component.wasm
+          # Deliberately NOT vendored into the repo. #219/#220 added a `cp` here
+          # to keep a committed artifact fresh, but the destination is gitignored
+          # (.gitignore:52) and absent from add-paths, so it was never once
+          # committed — `git log --all` on that path is empty. #243 settled the
+          # question the other way: committing the wasm shipped ~6 MB of
+          # unconsumed sdist weight per release, so the component is downloaded
+          # at runtime against the pinned version instead (see #286).
+          #
+          # component.wasm stays in the workspace: the WIT gate below reads it.
 
       - name: Install wasm-tools
         uses: taiki-e/install-action@v2
@@ -129,21 +135,42 @@ jobs:
 
       - name: Compose PR body
         id: body
+        # Body values arrive through `env:`, NOT `${{ }}` interpolation. A
+        # `${{ }}` expression is pasted into the script text before bash parses
+        # it, so the backticks inside `reasons` were parsed as command
+        # substitution: their contents were executed and replaced with the
+        # (empty) output, and the body read "WIT package version changed:  ->
+        # (host bindings in  likely need changes)" — losing exactly the two
+        # versions and the filename a reviewer needs. `set -euo pipefail` does
+        # not catch it, because the substitution's exit status is never
+        # examined. A shell variable's value is not re-scanned for
+        # substitutions, so `$REASONS` interpolates literally. This is also the
+        # standard fix for the script-injection surface `${{ }}`-into-`run`
+        # carries.
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          REASONS: ${{ steps.gate.outputs.reasons }}
+          NEW_WIT: ${{ steps.gate.outputs.new_wit }}
+          CUR_WIT: ${{ steps.gate.outputs.cur_wit }}
+          NEEDS_REVIEW: ${{ steps.gate.outputs.needs_review }}
         run: |
           set -euo pipefail
-          VERSION="${{ steps.version.outputs.version }}"
-          if [ "${{ steps.gate.outputs.needs_review }}" = "true" ]; then
+          if [ "$NEEDS_REVIEW" = "true" ]; then
             cat > pr-body.md <<EOF
           Automated update of rustledger to ${VERSION} — **held for human review** (draft, no auto-merge) because:
 
-          ${{ steps.gate.outputs.reasons }}
+          ${REASONS}
 
           ## What the bot already did
-          - Bumped \`RUSTLEDGER_VERSION\` and refreshed the vendored component (sha256-verified)
-          - Bumped \`_WIT_VERSION\` to \`${{ steps.gate.outputs.new_wit }}\` (if it changed)
+          - Bumped \`RUSTLEDGER_VERSION\` in \`engine.py\`
+          - Bumped \`_WIT_VERSION\` to \`${NEW_WIT}\` (if it changed)
+
+          The component is not vendored in this repo — it is gitignored and
+          downloaded at runtime against the pinned version. This run downloaded
+          the release asset and verified its sha256 in order to read its WIT.
 
           ## What a human must check
-          - [ ] New/changed WIT **imports**: does the component need host bindings the linker doesn't define yet? (\`wasm-tools component wit\` the vendored file; see the \`host\` interface handling in \`component_engine.py\`)
+          - [ ] New/changed WIT **imports**: does the component need host bindings the linker doesn't define yet? (\`wasm-tools component wit\` the release asset; see the \`host\` interface handling in \`component_engine.py\`)
           - [ ] Run the rustledger test suites locally (\`just test-py\`)
           - [ ] Update marshalling for any changed WIT types
 
@@ -153,7 +180,7 @@ jobs:
             cat > pr-body.md <<EOF
           Automated update of rustledger WASM version to ${VERSION}.
 
-          The component's WIT version matches the host bindings (\`${{ steps.gate.outputs.cur_wit }}\`) and the release notes carry no breaking markers, so this auto-merges once CI passes. The component was sha256-verified against the release asset.
+          The component's WIT version matches the host bindings (\`${CUR_WIT}\`) and the release notes carry no breaking markers, so this auto-merges once CI passes. The component was sha256-verified against the release asset.
 
           See [rustledger releases](https://github.com/rustledger/rustledger/releases) for the changelog.
           EOF


### PR DESCRIPTION
The remaining two defects from the #284 review, both in the upgrade bot's PR body.

## 1. The "why this is held" line silently lost its values

`${{ steps.gate.outputs.reasons }}` was interpolated into an **unquoted** heredoc. A `${{ }}` expression is pasted into the script *text* before bash parses it, so the backticks inside the reason string were parsed as command substitution — their contents executed, and replaced with the empty output. #284's body reads:

> - WIT package version changed:  ->  (host bindings in  likely need changes)

losing precisely the two versions and the filename the reviewer needs in order to do the review the PR is being held for. `set -euo pipefail` doesn't catch it, because the substitution's exit status is never examined.

**Fix:** pass the values through `env:` and reference them as shell variables. A variable's value is not re-scanned for substitutions, so backticks inside it stay literal. (The escaped static backticks elsewhere in the heredoc were never affected, which is why only the interpolated line broke.) This is also the standard remedy for the script-injection surface that `${{ }}`-into-`run` carries.

**Verified by executing the step** with the env the workflow supplies:

```
- WIT package version changed: `3.11.0` -> `4.0.0` (host bindings in `component_engine.py` likely need changes)
- Bumped `_WIT_VERSION` to `4.0.0` (if it changed)
```

and the same harness run against the pre-fix step reproduces the blanked line exactly, so the check demonstrably reports dirty as well as clean.

## 2. The body claimed a vendored artifact that has never existed

It advertised "refreshed the vendored component (sha256-verified)". The download step did:

```bash
cp component.wasm src/rustfava/rustledger/rustledger_ffi_component.wasm
```

added by #219/#220 to stop a committed artifact going stale. But that path is gitignored (`.gitignore:52`) and absent from `add-paths`, so it was **never once committed** — `git log --all` on the path is empty. The `cp` wrote into the runner's workspace and was thrown away, meaning the #219/#220 remediation has never had any effect.

#243 had already settled the question the other way: committing the wasm shipped ~6 MB of unconsumed sdist weight per release, so the component is downloaded at runtime against the pinned version instead (#286). So this removes the dead `cp` rather than resurrecting vendoring, and makes the body describe what actually happens.

The download and sha256 verification stay — the WIT gate reads `component.wasm` from the workspace. Also corrected the checklist item that told the reviewer to run `wasm-tools component wit` against "the vendored file", which is never there.

## Risk

No change to what the bot commits — only to the body it writes and to a `cp` whose output was discarded. YAML validated. actionlint reports one SC2086 finding, identical before and after this change (it's in the untouched "Get version" step), so nothing new is introduced; left alone as out of scope.