### PR TITLE
chore(deps): cover desktop manifests and hold TypeScript 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,36 @@ updates:
       frontend-dependencies:
         patterns:
           - "*"
+    ignore:
+      # TypeScript 7 is the native port and has no stable JS API yet, so every
+      # tool that reaches into the TS compiler API from JS breaks on it.
+      # typescript-eslint caps at <6.1.0 and its TS7 issue (#10940) is labelled
+      # "blocked by external API"; svelte-check and svelte2tsx cap at ^6. Until
+      # those ship support there is no route to TS7 — see #282, which this
+      # would otherwise regenerate every week.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+
+  # The desktop app has its own manifests and was covered by neither the
+  # /frontend npm entry nor any cargo entry, so its dependencies never received
+  # update PRs. Both had drifted several majors by the time this was noticed.
+  - package-ecosystem: "npm"
+    directory: "/desktop"
+    schedule:
+      interval: "weekly"
+    groups:
+      desktop-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/desktop/src-tauri"
+    schedule:
+      interval: "weekly"
+    groups:
+      desktop-rust-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Found while auditing every ecosystem for version drift.

## The gap

Dependabot watched `pip /`, `npm /frontend` and `github-actions /`. The repo also has **`desktop/package.json`** and **`desktop/src-tauri/Cargo.toml`**, which matched neither entry — so the desktop app's dependencies have never received a single update PR.

Both had drifted, several by a major:

| ecosystem | package | current | latest |
|---|---|---|---|
| npm `/desktop` | `@xterm/xterm` | 5.5.0 | **6.0.0** |
| | `@xterm/addon-fit` | 0.10.0 | **0.11.0** |
| | `@xterm/addon-web-links` | 0.11.0 | **0.12.0** |
| | `tauri-pty` | 0.2.1 | **0.3.1** |
| | `vite` | 8.0.16 | 8.2.2 |
| | `@tauri-apps/cli` | 2.11.2 | 2.11.4 |
| cargo `/desktop/src-tauri` | `tauri-plugin-pty` | 0.2 | **0.3.1** |
| | `tauri-build` | 2.1 | 2.6.3 |
| | `tauri-plugin-dialog` | 2.2 | 2.7.2 |
| | `tauri` | 2.5 | 2.11.5 |

Two things worth knowing when these PRs start arriving: `tauri-pty` and `tauri-plugin-pty` are the JS and Rust halves of the same 0.2 → 0.3 bump and will want landing together; and `desktop` pins `typescript` 5.9.3 while `frontend` is on 6.0.3.

I checked these entries have something to act on rather than silently matching nothing — both directories have tracked lockfiles (`desktop/bun.lock`, `desktop/src-tauri/Cargo.lock`), and `desktop/bun.lock` is the same format as `frontend/bun.lock`, which Dependabot already updates successfully (#282).

## Holding TypeScript majors on /frontend

TypeScript 7 is the native port and has no stable JS API yet, so every tool that reaches into the TS compiler API from JS breaks on it — `typescript-eslint` caps at `<6.1.0` with its TS7 issue labelled *"blocked by external API"*, and `svelte-check` / `svelte2tsx` cap at `^6`. There's no route to TS7 until those ship support (detail in #282), so without an ignore rule that PR simply regenerates every week.

The rule is scoped to majors only, so TS 6.x patches and minors still flow.

## Risk

No functional change; takes effect on the next Dependabot run. Reversing the TS hold is deleting four lines.