### PR TITLE
fix: put the pinned version in the component wasm filename

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag (e.g., v0.1.0)'
+        description: "Version tag (e.g., v0.1.0)"
         required: true
         type: string
   push:
     branches:
       - main
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
     branches:
       - main
@@ -93,17 +93,17 @@ jobs:
           gh release download ${{ steps.rustledger-tag.outputs.tag }} \
             --repo ${{ env.RUSTLEDGER_REPO }} \
             --pattern "rustledger-ffi-component-*.wasm" \
-            --output src/rustfava/rustledger/rustledger_ffi_component.wasm
+            --output "src/rustfava/rustledger/rustledger_ffi_component-${{ steps.rustledger-tag.outputs.tag }}.wasm"
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.13'
+          python-version: "3.13"
           # x64 on the macos-14 x86_64 entry = Intel Python under Rosetta (#222)
           architecture: ${{ matrix.python-arch }}
-          cache: 'pip'
+          cache: "pip"
 
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -376,7 +376,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           TAG=$(grep -oE 'RUSTLEDGER_VERSION = "v[0-9.]+"' src/rustfava/rustledger/engine.py | grep -oE 'v[0-9.]+')
           gh release download "$TAG" --repo rustledger/rustledger \
             --pattern "rustledger-ffi-component-*.wasm" \
-            --output src/rustfava/rustledger/rustledger_ffi_component.wasm
+            --output "src/rustfava/rustledger/rustledger_ffi_component-$TAG.wasm"
         env:
           GH_TOKEN: ${{ github.token }}
       - run: touch src/rustfava/static/app.js
@@ -95,7 +95,7 @@ jobs:
           TAG=$(grep -oE 'RUSTLEDGER_VERSION = "v[0-9.]+"' src/rustfava/rustledger/engine.py | grep -oE 'v[0-9.]+')
           gh release download "$TAG" --repo rustledger/rustledger \
             --pattern "rustledger-ffi-component-*.wasm" \
-            --output src/rustfava/rustledger/rustledger_ffi_component.wasm
+            --output "src/rustfava/rustledger/rustledger_ffi_component-$TAG.wasm"
         env:
           GH_TOKEN: ${{ github.token }}
       - run: touch src/rustfava/static/app.js

--- a/contrib/pyinstaller_spec.spec
+++ b/contrib/pyinstaller_spec.spec
@@ -52,9 +52,14 @@ if translations_dir.exists():
 # Rustledger engine: the in-process WASI Preview 2 component. Bundled when
 # present so the frozen app does not have to download it at first run (the
 # component_engine cache path is read-only inside the PyInstaller bundle).
-wasm_file = rustfava_dir / "rustledger" / "rustledger_ffi_component.wasm"
-if wasm_file.exists():
-    datas.append((str(wasm_file), "rustfava/rustledger"))
+# Globbed rather than named: the filename carries the pinned rustledger
+# version (rustfava#286), and this spec has no reason to know which.
+datas.extend(
+    (str(wasm_file), "rustfava/rustledger")
+    for wasm_file in (rustfava_dir / "rustledger").glob(
+        "rustledger_ffi_component-*.wasm"
+    )
+)
 
 # Help files
 help_dir = rustfava_dir / "help"

--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -20,6 +20,7 @@ mirroring the JSON-RPC surface's tagged unions.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import subprocess
@@ -154,7 +155,16 @@ def _default_wasm_path() -> Path:
     override = os.environ.get("RUSTLEDGER_COMPONENT_WASM")
     if override:
         return Path(override)
-    return Path(__file__).parent / "rustledger_ffi_component.wasm"
+    # The pinned version is part of the FILENAME, so bumping
+    # RUSTLEDGER_VERSION is a cache miss by construction. The name used to be
+    # version-agnostic while the download was guarded by `not exists()`, which
+    # meant a version bump never re-downloaded: a working tree kept using the
+    # previous release's component indefinitely, and the resulting test run
+    # was GREEN, so nothing prompted anyone to look (rustfava#286).
+    return (
+        Path(__file__).parent
+        / f"rustledger_ffi_component-{RUSTLEDGER_VERSION}.wasm"
+    )
 
 
 def _download_component_wasm(wasm_path: Path) -> None:
@@ -174,12 +184,34 @@ def _download_component_wasm(wasm_path: Path) -> None:
         wasm_path.parent.mkdir(parents=True, exist_ok=True)
         urllib.request.urlretrieve(_COMPONENT_WASM_URL, wasm_path)  # noqa: S310
         print("Done.", file=sys.stderr)  # noqa: T201
+        _prune_superseded_components(wasm_path)
     except Exception as e:  # noqa: BLE001
         wasm_path.unlink(missing_ok=True)
         print(  # noqa: T201
             f"Could not download component wasm: {e}",
             file=sys.stderr,
         )
+
+
+def _prune_superseded_components(current: Path) -> None:
+    """Delete component wasms for other versions sitting beside ``current``.
+
+    Versioned filenames would otherwise accumulate one ~7 MB artifact per
+    upgrade. Best-effort: a file that cannot be removed is left alone, since
+    failing to tidy up must never break a working engine.
+    """
+    superseded = list(current.parent.glob("rustledger_ffi_component-*.wasm"))
+    # Also reclaim the pre-#286 unversioned file, which is now never read and
+    # would otherwise sit dead in every existing checkout.
+    legacy = current.parent / "rustledger_ffi_component.wasm"
+    if legacy.exists():
+        superseded.append(legacy)
+    for stale in superseded:
+        if stale == current:
+            continue
+        # Tidy-up must never break a working engine.
+        with contextlib.suppress(OSError):
+            stale.unlink()
 
 
 def _snake(name: str) -> str:

--- a/tests/test_rustledger_component_marshal.py
+++ b/tests/test_rustledger_component_marshal.py
@@ -32,7 +32,9 @@ from rustfava.rustledger.component_engine import _download_component_wasm
 from rustfava.rustledger.component_engine import _drop_none
 from rustfava.rustledger.component_engine import _finalize_query_result
 from rustfava.rustledger.component_engine import _meta_value_json
+from rustfava.rustledger.component_engine import _prune_superseded_components
 from rustfava.rustledger.component_engine import _unwrap_query_value
+from rustfava.rustledger.component_engine import RUSTLEDGER_VERSION
 from rustfava.rustledger.component_engine import RustledgerComponentEngine
 from rustfava.rustledger.constants import Missing
 from rustfava.rustledger.engine import RustledgerError
@@ -54,7 +56,7 @@ def test_wasm_path_without_override(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     monkeypatch.delenv("RUSTLEDGER_COMPONENT_WASM", raising=False)
     path = _default_wasm_path()
-    assert path.name == "rustledger_ffi_component.wasm"
+    assert path.name == f"rustledger_ffi_component-{RUSTLEDGER_VERSION}.wasm"
     assert path.parent.name == "rustledger"
 
 
@@ -489,3 +491,44 @@ def test_missing_sentinel_is_falsy_singleton() -> None:
     assert Missing() is Missing()
     assert repr(Missing()) == "MISSING"
     assert not Missing()
+
+
+def test_prune_superseded_components(tmp_path: Path) -> None:
+    """Only the current component survives; older ones and the legacy name go.
+
+    The filename carries the pinned version (rustfava#286), so without this
+    every upgrade would leave another ~7 MB artifact behind forever.
+    """
+    current = tmp_path / f"rustledger_ffi_component-{RUSTLEDGER_VERSION}.wasm"
+    older = tmp_path / "rustledger_ffi_component-v0.0.1.wasm"
+    legacy = tmp_path / "rustledger_ffi_component.wasm"
+    unrelated = tmp_path / "keep-me.wasm"
+    for f in (current, older, legacy, unrelated):
+        f.write_bytes(b"\0asm")
+
+    _prune_superseded_components(current)
+
+    assert current.exists()
+    assert unrelated.exists()
+    assert not older.exists()
+    assert not legacy.exists()
+
+
+def test_prune_superseded_components_tolerates_unremovable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file that cannot be deleted must not break a working engine."""
+    current = tmp_path / f"rustledger_ffi_component-{RUSTLEDGER_VERSION}.wasm"
+    older = tmp_path / "rustledger_ffi_component-v0.0.1.wasm"
+    for f in (current, older):
+        f.write_bytes(b"\0asm")
+
+    denied = "permission denied"
+
+    def _boom(_self: Path, **_kwargs: object) -> None:
+        raise OSError(denied)
+
+    monkeypatch.setattr(Path, "unlink", _boom)
+    _prune_superseded_components(current)  # must not raise
+
+    assert older.exists()

--- a/tests/test_rustledger_component_marshal.py
+++ b/tests/test_rustledger_component_marshal.py
@@ -34,9 +34,9 @@ from rustfava.rustledger.component_engine import _finalize_query_result
 from rustfava.rustledger.component_engine import _meta_value_json
 from rustfava.rustledger.component_engine import _prune_superseded_components
 from rustfava.rustledger.component_engine import _unwrap_query_value
-from rustfava.rustledger.component_engine import RUSTLEDGER_VERSION
 from rustfava.rustledger.component_engine import RustledgerComponentEngine
 from rustfava.rustledger.constants import Missing
+from rustfava.rustledger.engine import RUSTLEDGER_VERSION
 from rustfava.rustledger.engine import RustledgerError
 
 


### PR DESCRIPTION
Closes #286.

## The bug

The cache path was version-agnostic (`rustledger_ffi_component.wasm`) and the download was guarded by `not exists()`. Together those mean bumping `RUSTLEDGER_VERSION` **never re-downloads** — a working tree keeps using the previous release's component indefinitely.

The failure mode is the bad one. While preparing #284 this reported **"669 passed"** against a tree pinned to v0.22.0 while actually running a component from an earlier release; after deleting the stale file the true result was **5 failed, 645 passed**, matching CI. A stale run is *green*, so nothing prompts anyone to look. CI is unaffected because it starts from a clean checkout — which means this hits contributors specifically, and hits them exactly when they bump the version, the moment the component matters most.

## Why the filename and not a marker

Putting the version in the filename makes a bump a cache miss **by construction**, rather than relying on a staleness check somebody has to maintain.

`desktop/scripts/ensure-rustledger.ts` solves this for a sibling wasm with a `.wasm-version` marker, and that was my first instinct. It's the wrong fit here: CI provisions the file directly without writing a marker, so a missing marker can't be distinguished from an externally provisioned file that happens to be stale — which is precisely the bug.

## Blast radius

I grepped for the literal filename before changing it; there were four other consumers, all updated:

- `.github/workflows/test.yml` (two download sites) and `desktop-release.yml` — all three already had the tag to hand
- `contrib/pyinstaller_spec.spec` — now globs, so it needn't know the version
- the `_default_wasm_path` assertion in `test_rustledger_component_marshal.py`

## Cleanup

Versioned names would otherwise accumulate one ~7 MB artifact per upgrade, so a successful download prunes its superseded siblings **and** the pre-#286 unversioned file, which is now dead in every existing checkout. Pruning is best-effort — a file that can't be removed is left alone, since tidy-up must never break a working engine.

## Verification

`just test-py`: **671 passed, 1 skipped, coverage 100.00%** — the gate is `--cov-fail-under=100` and `component_engine.py` isn't in the omit list, so the new function needed real tests rather than a pragma. Two were added, including one that asserts an unremovable file doesn't propagate.

Note `desktop-release.yml` carries a few unrelated quote-style changes: prettier normalizes the whole file whenever it's touched.