### PR TITLE
fix: repair sync-pre-commit and harden the bot's version step

### DIFF
--- a/.github/workflows/update-rustledger.yml
+++ b/.github/workflows/update-rustledger.yml
@@ -32,13 +32,29 @@ jobs:
 
       - name: Get version
         id: version
+        # Values arrive through `env:` rather than `${{ }}`, which is pasted
+        # into the script text before bash parses it. `client_payload.version`
+        # comes from a repository_dispatch payload, so interpolating it
+        # directly is the standard script-injection shape (same class as the
+        # PR-body bug fixed in #289).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.version }}"
+          set -euo pipefail
+          # `:-` because only one of the two is populated for any given
+          # event, and `set -u` would otherwise abort on the unused one.
+          if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
+            VERSION="${INPUT_VERSION:-}"
           else
-            VERSION="${{ github.event.client_payload.version }}"
+            VERSION="${PAYLOAD_VERSION:-}"
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if [ -z "$VERSION" ]; then
+            echo "no rustledger version supplied for event ${EVENT_NAME:-}" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Using rustledger version: $VERSION"
 
       - name: Download and verify the FFI component

--- a/frontend/sync-pre-commit.ts
+++ b/frontend/sync-pre-commit.ts
@@ -16,9 +16,55 @@ const lock_path = join(script_dir, "bun.lock");
 
 const config_path = join(script_dir, "..", ".pre-commit-config.yaml");
 
+/**
+ * Strip JSONC trailing commas so `JSON.parse` accepts a `bun.lock`.
+ *
+ * bun writes trailing commas, which every strict parser rejects — both
+ * `JSON.parse` and `Bun.file().json()`. Commas are only dropped when the next
+ * non-whitespace character closes the enclosing object or array, and string
+ * literals are skipped, so a comma inside a package name or version range can
+ * never be mistaken for a structural one.
+ */
+function strip_trailing_commas(text: string): string {
+  let out = "";
+  let in_string = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i] ?? "";
+    if (in_string) {
+      out += ch;
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        in_string = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      in_string = true;
+      out += ch;
+      continue;
+    }
+    if (ch === ",") {
+      let j = i + 1;
+      while (j < text.length && /\s/.test(text[j] ?? "")) {
+        j += 1;
+      }
+      const next = text[j];
+      if (next === "}" || next === "]") {
+        continue;
+      }
+    }
+    out += ch;
+  }
+  return out;
+}
+
 async function main() {
   const lock_content = await readFile(lock_path, "utf-8");
-  const bun_lock = JSON.parse(lock_content) as BunLock;
+  const bun_lock = JSON.parse(strip_trailing_commas(lock_content)) as BunLock;
   const packages = bun_lock.packages;
 
   const current_config = await readFile(config_path, "utf-8");
@@ -43,4 +89,7 @@ async function main() {
 
 main().catch((e: unknown) => {
   console.error(e);
+  // Without this the script exits 0 on failure, so a parse error looked like a
+  // successful no-op and the pre-commit version pins silently stopped syncing.
+  process.exitCode = 1;
 });


### PR DESCRIPTION
Two independent **silent** failures found while reviewing #284 / #287 / #289. Same family as those: something that looks like it worked, didn't.

## 1. `sync-pre-commit` couldn't parse `bun.lock`, and hid it

`JSON.parse` rejected the lockfile with *"Property name must be a string literal"* — bun writes JSONC with trailing commas (first one after `web-tree-sitter`, line 34). `Bun.file().json()` is equally strict, so there was no drop-in.

The script then swallowed it: `main().catch()` logged the error and left the exit code at **0**. So `just sync-pre-commit` and the package script both reported success while doing nothing.

Fixed by stripping trailing commas before parsing — skipping string literals, so a comma inside a package name or version range can't be mistaken for a structural one — and setting `process.exitCode = 1` in the catch.

Verified:

| case | before | after |
|---|---|---|
| real `bun.lock` | threw, exit 0 | parses **385 package entries**, exit 0 |
| corrupted lockfile | exit 0 | **exit 1** |

**Worth knowing:** the script has nothing to rewrite today regardless. It looks for `"name@version"` strings and `.pre-commit-config.yaml` no longer contains any — the biome hook pins a `rev:`, and the sole `additional_dependencies` entry is unversioned. That format did exist historically (it's still invoked from `justfile:253`). Someone should decide whether the script is still wanted; this at least makes it say so when it breaks.

## 2. The bot's "Get version" step interpolated a dispatch payload into bash

```yaml
VERSION="${{ github.event.client_payload.version }}"
```

`${{ }}` is pasted into the script text before bash parses it — the standard script-injection shape, and the same class as the PR-body bug fixed in #289. Here the value arrives from a `repository_dispatch` payload. Moved to `env:`.

Also in this step: quotes `$GITHUB_OUTPUT` (the SC2086 actionlint has been reporting on this workflow — I'd left it alone in #287 as out of scope), adds `set -euo pipefail`, and fails loudly when neither input supplies a version instead of continuing with an empty one. Reads use `${VAR:-}` because only one of the two is populated for any given event, and `set -u` would otherwise abort on the unused one.

**actionlint on this workflow now exits 0**, from one finding before — checked via exit code, not grepped output.

Simulated all three paths:

```
workflow_dispatch    -> version=v0.23.0   exit 0
repository_dispatch  -> version=v0.24.0   exit 0
neither supplied     -> "no rustledger version supplied", exit 1
```

## Risk

`tsc` and `eslint` pass on the changed script. The workflow change affects only how the version is read; no change to what the bot commits.