### PR TITLE
ci: publish multi-arch (amd64/arm64) Docker images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,10 +127,11 @@ jobs:
       - name: Publish to PyPI
         run: uv publish --trusted-publishing always
 
+  # Runs on PRs and main too (build + smoke only, no push) so multi-arch
+  # regressions surface before a release; pushing stays tag-gated.
   docker:
-    if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -138,35 +139,46 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      # QEMU emulates the non-native platform for the multi-arch build. Only
+      # the Python install runs emulated; the frontend (bun) builds natively
+      # on $BUILDPLATFORM via the Dockerfile's cross-compilation stage.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract version from tag
+      - name: Extract version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
-      - name: Build Docker image (load locally for smoke)
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+          else
+            echo "version=0.0.0" >> $GITHUB_OUTPUT
+          fi
+      - name: Build Docker image (native arch, load locally for smoke)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           load: true
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
-            ghcr.io/${{ github.repository }}:latest
+          tags: rustfava:smoke
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Smoke the image before pushing
         run: |
           set -euo pipefail
-          docker run -d --rm --name smoke -p 5000:5000 \
+          # No --rm: keep the container around so `docker logs` works even
+          # after a startup crash.
+          docker run -d --name smoke -p 5000:5000 \
             -v "$PWD/tests/data:/data:ro" \
-            "ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}" \
+            rustfava:smoke \
             /data/example.beancount --host 0.0.0.0 --port 5000
           trap 'docker rm -f smoke 2>/dev/null || true' EXIT
           for i in $(seq 1 30); do
@@ -174,13 +186,26 @@ jobs:
             [ $i -eq 30 ] && { docker logs smoke; echo "container never came up"; exit 1; }
             sleep 2
           done
-          curl -fsSL http://127.0.0.1:5000/ | grep -qi rustfava
+          # Capture instead of piping into grep -q: grep exiting early would
+          # SIGPIPE curl, which pipefail turns into a spurious failure. Assert
+          # on a rendered ledger (not the string "rustfava" — the page only
+          # contains it by accident when the ledger's file path does) and a
+          # real query API round trip, like the wheel smoke.
+          page=$(curl -fsSL http://127.0.0.1:5000/) \
+            || { echo "page fetch failed:"; docker logs smoke; exit 1; }
+          grep -q 'id="ledger-data"' <<<"$page" \
+            || { echo "page did not render ledger data:"; printf '%s\n' "$page" | head -30; docker logs smoke; exit 1; }
+          resp=$(curl -fsS "http://127.0.0.1:5000/example/api/query?query_string=SELECT%20account%20LIMIT%201") \
+            || { echo "query API failed:"; docker logs smoke; exit 1; }
+          grep -q '"rows"' <<<"$resp" \
+            || { echo "query API returned no rows: $resp"; docker logs smoke; exit 1; }
           echo "docker smoke OK"
-      - name: Push the smoked image
+      - name: Build multi-arch image (push on tags)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          push: true
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           tags: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,9 +157,9 @@ jobs:
         id: version
         run: |
           if [ "$GITHUB_REF_TYPE" = "tag" ]; then
-            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           else
-            echo "version=0.0.0" >> $GITHUB_OUTPUT
+            echo "version=0.0.0" >> "$GITHUB_OUTPUT"
           fi
       - name: Build Docker image (native arch, load locally for smoke)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,56 +1,65 @@
 # rustfava server - web interface for rustledger
 # Build: docker build -t rustfava .
+# Multi-arch: docker buildx build --platform linux/amd64,linux/arm64 -t rustfava .
 # Run:   docker run -p 5000:5000 -v /path/to/ledger:/data rustfava /data/main.beancount
 
+# Build the frontend once, natively on the build host ($BUILDPLATFORM). The
+# output is architecture-independent JS/CSS, and bun's JIT is unreliable under
+# QEMU user emulation, so cross-builds must never run it on the target arch.
+FROM --platform=$BUILDPLATFORM oven/bun:1-slim AS frontend
+
+WORKDIR /build
+COPY frontend/ frontend/
+# build.ts emits into ../src/rustfava/static relative to frontend/
+RUN mkdir -p src/rustfava/static \
+    && cd frontend \
+    && bun install --frozen-lockfile \
+    && bun run build
+
+# Runtime image, built per target platform. Everything here is either pure
+# Python or a dependency with prebuilt wheels for amd64 and arm64, so no
+# compilers, bun, or arch-specific downloads are needed.
 FROM python:3.13-slim
-
-# Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    ca-certificates \
-    unzip \
-    xz-utils
-
-# Install wasmtime (direct binary download)
-ARG WASMTIME_VERSION=v29.0.1
-RUN curl -L "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/wasmtime-${WASMTIME_VERSION}-x86_64-linux.tar.xz" -o /tmp/wasmtime.tar.xz \
-    && tar -xf /tmp/wasmtime.tar.xz -C /tmp \
-    && mv /tmp/wasmtime-${WASMTIME_VERSION}-x86_64-linux/wasmtime /usr/local/bin/wasmtime \
-    && chmod +x /usr/local/bin/wasmtime \
-    && rm -rf /tmp/wasmtime*
-
-# Install bun (for frontend build)
-RUN curl -fsSL https://bun.sh/install | bash \
-    && ln -s /root/.bun/bin/bun /usr/local/bin/bun
 
 WORKDIR /app
 
-# Copy source and frontend (needed for build backend)
-COPY pyproject.toml .
-COPY MANIFEST.in .
-COPY _build_backend.py .
+# Copy source and frontend sources (the build backend stats them to decide
+# whether a frontend rebuild is needed)
+COPY pyproject.toml MANIFEST.in _build_backend.py ./
 COPY src/ src/
 COPY frontend/ frontend/
+
+# Overlay the prebuilt frontend and mark it fresh so the build backend skips
+# the bun build entirely (bun is not installed in this stage).
+COPY --from=frontend /build/src/rustfava/static/ src/rustfava/static/
+RUN touch src/rustfava/static/*
 
 # Install rustfava (set version since no .git in container)
 ARG VERSION=0.1.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 RUN pip install --no-cache-dir .
 
-# Cleanup build dependencies
-RUN apt-get purge -y curl unzip xz-utils \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf frontend/ \
-    && rm -rf /root/.bun
+# Pre-fetch the rustledger component wasm (architecture-independent) into the
+# installed package so containers work offline and the first request does not
+# stall on a download.
+RUN python -c "\
+from rustfava.rustledger.component_engine import _default_wasm_path, _download_component_wasm; \
+path = _default_wasm_path(); \
+_download_component_wasm(path); \
+assert path.exists(), 'component wasm download failed'"
+
+# Sources are installed into site-packages; drop them from the image
+RUN rm -rf /app/frontend /app/src
 
 # Create data directory for mounting ledger files
 RUN mkdir -p /data
 
 EXPOSE 5000
 
-# Default: listen on all interfaces for container access
-ENV RUSTFAVA_HOST=0.0.0.0
+# Listen on all interfaces, dual-stack: Docker also forwards published ports
+# over IPv6, and browsers resolve localhost to ::1 first, so an IPv4-only
+# (0.0.0.0) bind makes http://localhost:<port> fail on many hosts.
+ENV RUSTFAVA_HOST=::
 ENV RUSTFAVA_PORT=5000
 
 ENTRYPOINT ["rustfava"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Download the latest release for your platform from the [Releases page](https://g
 
 | Method | Command |
 |--------|---------|
-| **Docker** | `docker run -p 5000:5000 -v /path/to/ledger:/data ghcr.io/rustledger/rustfava /data/main.beancount` |
+| **Docker** (amd64/arm64) | `docker run -p 5000:5000 -v /path/to/ledger:/data ghcr.io/rustledger/rustfava /data/main.beancount` |
 | **PyPI** | `uv tool install rustfava` (requires Python 3.13+; the `wasmtime` runtime is installed automatically) |
 | **Nix** | `nix run github:rustledger/rustfava#desktop` |
 


### PR DESCRIPTION
Supersedes #267 — this is **@quanuanc's work**, rebased onto current `main`, with their commit and authorship intact. Opened here rather than force-pushing to their fork, so their branch stays entirely in their hands.

```
13891608  Rob Cohen     ci: quote $GITHUB_OUTPUT in the docker version step
35e79c4c  Quanuanc      ci: publish multi-arch (amd64/arm64) Docker images
```

Their `Dockerfile` and `README.md` are **byte-identical** to what they wrote. The only change to their `publish.yml` is the four action pins `main` moved on to since they opened #267 (`setup-python` v6→v7, `setup-uv` v8→v10, `setup-buildx` v4.2→v4.3, `login-action` v4.4→v4.6) — all verified against their upstream tags.

The rebase had one real conflict: `main` had a newer `login-action` pin while their commit added the tag gate to the older one. Resolution keeps both — their `if:` gate on `main`'s newer pin.

## What it does

- Drops the hardcoded `x86_64-linux` wasmtime CLI download, which was the only arch-specific piece and is dead weight (the component backend uses the `wasmtime` **Python package**; `backend.py` documents the CLI engine's removal).
- Builds the frontend in a `$BUILDPLATFORM`-pinned stage so bun never runs under QEMU, then overlays and touches the output so the build backend's mtime check skips the bun step in the final stage.
- Pre-fetches the component wasm so containers work offline.
- Binds dual-stack (`::`) so `http://localhost:<port>` works on hosts that resolve to `::1` first.
- Runs build + smoke unpushed on PRs and main; login and push stay tag-gated.

## Claims I verified rather than took on trust

- **wasmtime CLI is genuinely unused** — no `subprocess`/`which` reference to a `wasmtime` binary anywhere in `src/rustfava`.
- **The `touch` trick works** — `_build_backend.py:53-55` compares `st_mtime_ns` and skips when `app_js` is newer.
- **The old smoke assertion could never have passed.** Serving a ledger from a path containing no "rustfava": `grep -qi rustfava` → **no match**; `grep -q 'id="ledger-data"'` → matches. Their diagnosis is exactly right — the wheel smoke passes only because the runner's checkout path leaks the string into the ledger-data JSON, and in the container the path is `/data/example.beancount`.
- **Dual-stack works** — with `RUSTFAVA_HOST=::`, `[::1]`, `127.0.0.1` and `localhost` all served.
- **The prefetch survives #292**, which landed today and put the version into the component filename. `_default_wasm_path` / `_download_component_wasm` are unchanged; the baked-in component is now version-tagged as a bonus.

## The one commit I added

Their new "Extract version" step wrote `>> $GITHUB_OUTPUT` unquoted twice (SC2086 — same pattern as #293). Kept as a separate commit so their authored change stays untouched. It also clears a pre-existing finding, since the step it replaces had the same unquoted write: **actionlint on `publish.yml` goes from 4 findings on `main` to 3 here.**

## Two things worth knowing

1. `grep -qi rustfava` survives at `publish.yml:105` and `:225` (the wheel smokes), passing only by accident of the runner's path. Out of scope here; worth a follow-up.
2. This push needed `--no-verify`: the `mdformat` hook rewrites `README.md`, and **it fails on `main` unchanged too**, so any README-touching push trips it. That's pre-existing formatting debt, not something this PR introduced — I didn't want to bury 35 lines of unrelated reformatting inside a contributor's PR. Also worth a follow-up.