### PR TITLE
chore: make every markdown file mdformat-clean

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,15 @@ repos:
         args: ["--wrap", "80"]
         additional_dependencies:
           - mdformat-gfm
+        # docs/api.md carries two indentation-significant mkdocs constructs
+        # mdformat does not understand: a `!!! note` admonition and an
+        # mkdocstrings `::: rustfava.core` block with an indented `options:`
+        # mapping. Reflowing joins their indented bodies onto the marker line,
+        # which turns the identifier into `rustfava.core options:
+        # show_submodules: true` and fails `mkdocs build --strict` with
+        # "Could not collect". Excluded rather than plugin-patched, so the
+        # wrap behaviour of every other file stays unchanged.
+        exclude: ^docs/api\.md$
 
   - repo: https://github.com/biomejs/pre-commit
     rev: v2.3.12

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,8 @@ If you want to report a security issue, please open an issue on GitHub.
 
 ### Contributing code
 
-Make a fork and submit your Pull Request. If it's a
-large change or you want some help to get started with coding, open an issue
-beforehand to discuss it.
+Make a fork and submit your Pull Request. If it's a large change or you want
+some help to get started with coding, open an issue beforehand to discuss it.
 
 Please contribute tests as well. See the `tests/` subdirectory for existing
 tests, which can be run with `just test`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,10 +5,11 @@ This document describes the release process for rustfava.
 ## Overview
 
 A release involves:
+
 1. Creating a git tag
-2. Automated builds (desktop apps, PyPI, Docker)
-3. Publishing the release
-4. Updating Nix flake sources
+1. Automated builds (desktop apps, PyPI, Docker)
+1. Publishing the release
+1. Updating Nix flake sources
 
 ## Step-by-Step Process
 
@@ -25,21 +26,22 @@ git push origin v0.1.x
 
 The tag triggers several workflows:
 
-| Workflow | Purpose | Duration |
-|----------|---------|----------|
-| `desktop-release.yml` | Builds desktop apps for all platforms | ~10 min |
-| `build-publish.yml` | Builds and publishes to PyPI, Docker, COPR | ~60 min |
+| Workflow              | Purpose                                    | Duration |
+| --------------------- | ------------------------------------------ | -------- |
+| `desktop-release.yml` | Builds desktop apps for all platforms      | ~10 min  |
+| `build-publish.yml`   | Builds and publishes to PyPI, Docker, COPR | ~60 min  |
 
 Monitor at: https://github.com/rustledger/rustfava/actions
 
 ### 3. PyPI deployment
 
-Publishes automatically when the `build-publish.yml` workflow reaches the
-`pypi` job — no manual approval is configured (verified during v1.31.0).
+Publishes automatically when the `build-publish.yml` workflow reaches the `pypi`
+job — no manual approval is configured (verified during v1.31.0).
 
 ### 4. Publish the GitHub release
 
 Once `desktop-release.yml` completes, it creates a **draft release** with:
+
 - `.AppImage` (Linux)
 - `.deb`, `.rpm` (Linux packages)
 - `.dmg` (macOS)
@@ -47,6 +49,7 @@ Once `desktop-release.yml` completes, it creates a **draft release** with:
 - `.tar.gz` (Linux tarball for Nix)
 
 Publish it:
+
 ```bash
 gh release edit v0.1.x --draft=false
 ```
@@ -58,9 +61,10 @@ Or via GitHub UI: https://github.com/rustledger/rustfava/releases
 The `update-flake-sources.yml` workflow fires when a tag-triggered
 `Desktop Release` run completes (it can also be run manually via
 `gh workflow run update-flake-sources.yml -f version=vX.Y.Z`). It:
+
 1. Downloads release tarballs
-2. Computes SRI hashes
-3. Creates a PR updating `desktop-sources.json`
+1. Computes SRI hashes
+1. Creates a PR updating `desktop-sources.json`
 
 Merge the PR when it passes CI.
 
@@ -85,24 +89,29 @@ docker pull ghcr.io/rustledger/rustfava:0.1.x
 
 ## Release Artifacts
 
-| Artifact | Source | Distribution |
-|----------|--------|--------------|
-| Desktop apps | `desktop-release.yml` | GitHub Releases |
-| Python package | `build-publish.yml` | PyPI |
-| Docker image | `build-publish.yml` | GHCR |
-| Nix flake | `flake.nix` + `desktop-sources.json` | GitHub |
+| Artifact       | Source                               | Distribution    |
+| -------------- | ------------------------------------ | --------------- |
+| Desktop apps   | `desktop-release.yml`                | GitHub Releases |
+| Python package | `build-publish.yml`                  | PyPI            |
+| Docker image   | `build-publish.yml`                  | GHCR            |
+| Nix flake      | `flake.nix` + `desktop-sources.json` | GitHub          |
 
 ## Troubleshooting
 
 ### Draft release not created
-Check that `desktop-release.yml` completed successfully. The release job only runs on tags.
+
+Check that `desktop-release.yml` completed successfully. The release job only
+runs on tags.
 
 ### Nix flake sources not updated
-The `update-flake-sources.yml` workflow triggers when the tag's `Desktop
-Release` run completes successfully. If it didn't fire, dispatch it manually:
-`gh workflow run update-flake-sources.yml -f version=vX.Y.Z`.
+
+The `update-flake-sources.yml` workflow triggers when the tag's
+`Desktop Release` run completes successfully. If it didn't fire, dispatch it
+manually: `gh workflow run update-flake-sources.yml -f version=vX.Y.Z`.
 
 ### PyPI publish failed
+
 Check the workflow logs. Common issues:
+
 - Version already exists on PyPI (can't overwrite)
 - Missing approval for the `pypi` environment

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,9 +5,11 @@
 If you discover a security vulnerability in rustfava, please report it through
 GitHub's private vulnerability reporting:
 
-1. Go to the [Security Advisories](https://github.com/rustledger/rustfava/security/advisories) page
-2. Click "Report a vulnerability"
-3. Provide details about the vulnerability
+1. Go to the
+   [Security Advisories](https://github.com/rustledger/rustfava/security/advisories)
+   page
+1. Click "Report a vulnerability"
+1. Provide details about the vulnerability
 
 We will respond within 48 hours and work with you to address the issue.
 

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -2,7 +2,8 @@
 
 ## Quick Start (Pre-built Image)
 
-The easiest way to run rustfava with Docker is using the pre-built image from GitHub Container Registry:
+The easiest way to run rustfava with Docker is using the pre-built image from
+GitHub Container Registry:
 
 ```bash
 docker run -p 5000:5000 -v /path/to/ledger:/data ghcr.io/rustledger/rustfava /data/main.beancount
@@ -45,11 +46,13 @@ Visit http://localhost:5000 to access rustfava.
 
 ## Advanced Deployment
 
-For production deployments with authentication and HTTPS, see the following sections.
+For production deployments with authentication and HTTPS, see the following
+sections.
 
 ### Reverse Proxy with Authentication
 
-For a secure, authenticated deployment, use a reverse proxy like nginx or Caddy with OAuth2 authentication.
+For a secure, authenticated deployment, use a reverse proxy like nginx or Caddy
+with OAuth2 authentication.
 
 Example with [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy):
 
@@ -74,7 +77,8 @@ docker run --detach --name="rustfava-auth" \
 
 ### HTTPS with Let's Encrypt
 
-For automatic HTTPS certificates, use [Caddy](https://caddyserver.com/) as a reverse proxy:
+For automatic HTTPS certificates, use [Caddy](https://caddyserver.com/) as a
+reverse proxy:
 
 ```yaml
 # docker-compose.yml

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,6 +1,7 @@
 # rustfava Desktop App
 
-A native desktop application wrapper for rustfava, built with [Tauri](https://tauri.app/).
+A native desktop application wrapper for rustfava, built with
+[Tauri](https://tauri.app/).
 
 ## Features
 
@@ -43,9 +44,11 @@ bun tauri build
 ```
 
 Output locations:
+
 - **Linux deb**: `src-tauri/target/release/bundle/deb/rustfava_*.deb`
 - **Linux rpm**: `src-tauri/target/release/bundle/rpm/rustfava-*.rpm`
-- **Linux AppImage**: `src-tauri/target/release/bundle/appimage/rustfava_*.AppImage`
+- **Linux AppImage**:
+  `src-tauri/target/release/bundle/appimage/rustfava_*.AppImage`
 - **macOS**: `src-tauri/target/release/bundle/macos/rustfava.app`
 - **Windows**: `src-tauri/target/release/bundle/msi/rustfava_*.msi`
 
@@ -54,10 +57,10 @@ Output locations:
 The app uses a "sidecar" pattern:
 
 1. Tauri app launches and shows a file picker
-2. When a file is selected, it spawns the bundled `rustfava-server` binary
-3. The server runs on a random available port
-4. The webview loads the rustfava web UI from localhost
-5. On window close, the server process is terminated
+1. When a file is selected, it spawns the bundled `rustfava-server` binary
+1. The server runs on a random available port
+1. The webview loads the rustfava web UI from localhost
+1. On window close, the server process is terminated
 
 ## Files
 
@@ -79,6 +82,7 @@ git push origin v0.1.0
 Or trigger manually from the Actions tab → "Desktop Release" → "Run workflow".
 
 The workflow builds for:
+
 - **Linux**: `.deb`, `.rpm`, `.AppImage` (x86_64)
 - **macOS**: `.dmg` (x86_64 Intel + ARM64 Apple Silicon)
 - **Windows**: `.msi`, `.exe` installer (x86_64)
@@ -86,13 +90,15 @@ The workflow builds for:
 ### How it works
 
 1. **Build sidecars**: PyInstaller creates platform-specific rustfava binaries
-2. **Build Tauri**: Each platform builds the Tauri app with its sidecar
-3. **Release**: Artifacts are uploaded to a draft GitHub Release
+1. **Build Tauri**: Each platform builds the Tauri app with its sidecar
+1. **Release**: Artifacts are uploaded to a draft GitHub Release
 
 ### Local cross-compilation
 
-You cannot easily cross-compile (e.g., build Windows from Linux). Each platform must be built natively. For local testing:
+You cannot easily cross-compile (e.g., build Windows from Linux). Each platform
+must be built natively. For local testing:
 
 - **Linux**: `nix develop && cd desktop && bun tauri build`
 - **macOS**: Install Xcode, Rust, Bun, then `cd desktop && bun tauri build`
-- **Windows**: Install Visual Studio Build Tools, Rust, Bun, then `cd desktop && bun tauri build`
+- **Windows**: Install Visual Studio Build Tools, Rust, Bun, then
+  `cd desktop && bun tauri build`

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,13 +1,11 @@
 # API Reference
 
-!!! note
-    There's no stability guarantee as this is just for internal purposes currently.
+!!! note There's no stability guarantee as this is just for internal purposes
+currently.
 
 ## Core Modules
 
-::: rustfava.core
-    options:
-      show_submodules: true
+::: rustfava.core options: show_submodules: true
 
 ## Application
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,11 +1,13 @@
 # API Reference
 
-!!! note There's no stability guarantee as this is just for internal purposes
-currently.
+!!! note
+    There's no stability guarantee as this is just for internal purposes currently.
 
 ## Core Modules
 
-::: rustfava.core options: show_submodules: true
+::: rustfava.core
+    options:
+      show_submodules: true
 
 ## Application
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,7 +9,8 @@ system package manager):
 - [Python 3.13+](https://www.python.org/) - as rustfava is written in Python
 - [Bun](https://bun.sh/) - to build the frontend
 - [just](https://just.systems/) - to run various build / lint / test targets
-- [uv](https://docs.astral.sh/uv/) - to install the development environment and run scripts
+- [uv](https://docs.astral.sh/uv/) - to install the development environment and
+  run scripts
 
 Then this will get you up and running:
 
@@ -21,8 +22,9 @@ cd rustfava
 just dev
 ```
 
-You can start rustfava in the virtual environment as usual by running `rustfava`.
-Running in debug mode with `rustfava --debug` is useful for development.
+You can start rustfava in the virtual environment as usual by running
+`rustfava`. Running in debug mode with `rustfava --debug` is useful for
+development.
 
 You can run the tests with `just test` and the linters by running `just lint`.
 Run `just --list` to see all available recipes. After any changes to the
@@ -34,4 +36,5 @@ the Javascript bundle continuously.
 Contributions are very welcome, just open a PR on
 [GitHub](https://github.com/rustledger/rustfava/pulls).
 
-Rustfava is released under the [MIT License](https://github.com/rustledger/rustfava/blob/main/LICENSE).
+Rustfava is released under the
+[MIT License](https://github.com/rustledger/rustfava/blob/main/LICENSE).

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,9 @@ If you are new to rustfava or Beancount-format files, begin with the
 
 ### Desktop App (Recommended)
 
-Download the desktop app from [GitHub Releases](https://github.com/rustledger/rustfava/releases) - no installation required, just double-click to run.
+Download the desktop app from
+[GitHub Releases](https://github.com/rustledger/rustfava/releases) - no
+installation required, just double-click to run.
 
 ### Command Line
 

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -1,16 +1,19 @@
 # Syncing with Upstream Fava
 
-rustfava is a fork of [Fava](https://github.com/beancount/fava) that replaces the beancount parser with [rustledger](https://github.com/rustledger/rustledger). This document describes how to sync relevant changes from upstream.
+rustfava is a fork of [Fava](https://github.com/beancount/fava) that replaces
+the beancount parser with
+[rustledger](https://github.com/rustledger/rustledger). This document describes
+how to sync relevant changes from upstream.
 
 ## Background
 
 The fork diverges significantly from upstream in the backend:
 
-| Component | Fava | rustfava |
-|-----------|------|----------|
-| Parser | Python beancount | rustledger (WASM) |
-| Core modules | `fava/core/`, `fava/beans/` | `rustfava/rustledger/` |
-| Package manager | npm | bun |
+| Component       | Fava                        | rustfava               |
+| --------------- | --------------------------- | ---------------------- |
+| Parser          | Python beancount            | rustledger (WASM)      |
+| Core modules    | `fava/core/`, `fava/beans/` | `rustfava/rustledger/` |
+| Package manager | npm                         | bun                    |
 
 The frontend is largely unchanged and can usually accept upstream patches.
 
@@ -96,11 +99,14 @@ git cherry-pick --continue
 
 ### File renames (fava -> rustfava)
 
-Upstream references `src/fava/` but rustfava uses `src/rustfava/`. The cherry-pick usually handles this via directory mapping, but manual fixes may be needed.
+Upstream references `src/fava/` but rustfava uses `src/rustfava/`. The
+cherry-pick usually handles this via directory mapping, but manual fixes may be
+needed.
 
 ### Deleted core files
 
-If upstream modifies files that rustfava deleted (like `core/inventory.py`), skip the commit:
+If upstream modifies files that rustfava deleted (like `core/inventory.py`),
+skip the commit:
 
 ```bash
 git cherry-pick --skip
@@ -109,20 +115,22 @@ git cherry-pick --skip
 ## After Syncing
 
 1. **Run the test suite**: `just test`
-2. **Build the frontend**: `just frontend`
-3. **Manual testing**: Start the app and verify functionality
-4. **Update this doc**: Note the last sync date and any new patterns
+1. **Build the frontend**: `just frontend`
+1. **Manual testing**: Start the app and verify functionality
+1. **Update this doc**: Note the last sync date and any new patterns
 
 ## Sync History
 
-| Date | PR | Commits | Notes |
-|------|-----|---------|-------|
-| 2026-01-25 | #22 | 2 | Extension types, router improvements |
+| Date       | PR  | Commits | Notes                                |
+| ---------- | --- | ------- | ------------------------------------ |
+| 2026-01-25 | #22 | 2       | Extension types, router improvements |
 
 ## Upstream Monitoring
 
 Consider setting up notifications for upstream releases:
 
 1. Watch the [beancount/fava](https://github.com/beancount/fava) repository
-2. Review the [Fava changelog](https://github.com/beancount/fava/blob/main/CHANGELOG.md) periodically
-3. Sync quarterly or when significant features are added
+1. Review the
+   [Fava changelog](https://github.com/beancount/fava/blob/main/CHANGELOG.md)
+   periodically
+1. Sync quarterly or when significant features are added

--- a/src/rustfava/help/_index.md
+++ b/src/rustfava/help/_index.md
@@ -11,14 +11,14 @@ following topics:
 - [Import](./import) - the import system.
 - [Options](./options) - the available options.
 
-Rustfava comes with keyboard shortcuts - press <kbd>?</kbd> on any page to see the
-available ones.
+Rustfava comes with keyboard shortcuts - press <kbd>?</kbd> on any page to see
+the available ones.
 
-If you started rustfava from the command line, you can run `rustfava --help` to see all
-the available command line options.
+If you started rustfava from the command line, you can run `rustfava --help` to
+see all the available command line options.
 
-If you discover a bug in rustfava, or have some ideas for improvement, please open a
-[bug report](https://github.com/rustledger/rustfava/issues).
+If you discover a bug in rustfava, or have some ideas for improvement, please
+open a [bug report](https://github.com/rustledger/rustfava/issues).
 
 ### Related websites
 

--- a/src/rustfava/help/beancount_syntax.md
+++ b/src/rustfava/help/beancount_syntax.md
@@ -65,10 +65,10 @@ To open or close an account use the `open` and `close` directives:
 
 Declaring commodities is optional. Use this if you want to attach metadata by
 currency. If you specify a `name` for a currency like below, this name will be
-displayed as a tooltip on hovering over currency names in rustfava. Likewise, with
-the `precision` metadata, you can specify the number of decimal digits to show
-in rustfava, overriding the precision that is otherwise automatically inferred from
-the input data.
+displayed as a tooltip on hovering over currency names in rustfava. Likewise,
+with the `precision` metadata, you can specify the number of decimal digits to
+show in rustfava, overriding the precision that is otherwise automatically
+inferred from the input data.
 
 <pre><textarea is="beancount-textarea">
 1998-07-22 commodity AAPL

--- a/src/rustfava/help/budgets.md
+++ b/src/rustfava/help/budgets.md
@@ -21,11 +21,11 @@ summed up for a range of dates as needed.
 This makes the budgets very flexible, allowing for a monthly budget, being taken
 over by a weekly budget, and so on.
 
-Rustfava displays budgets in both charts and reports. You can find a visualization
-of the global budget in the `Net Profit` and `Expenses` charts for the Income
-Statement report.
+Rustfava displays budgets in both charts and reports. You can find a
+visualization of the global budget in the `Net Profit` and `Expenses` charts for
+the Income Statement report.
 
 The Income Statement report is a good starting point for getting access to the
-full budget information in rustfava. The `Changes` charts visualize the data. The
-`Changes (monthly)` and `Balances (monthly)` reports show, respectively, the
+full budget information in rustfava. The `Changes` charts visualize the data.
+The `Changes (monthly)` and `Balances (monthly)` reports show, respectively, the
 monthly and cumulative (over the selected period) budgets.

--- a/src/rustfava/help/conversion.md
+++ b/src/rustfava/help/conversion.md
@@ -1,8 +1,8 @@
 # Conversion
 
-In most reports in rustfava, a conversion can be selected with the select dropdown
-at the top of the chart. These conversions will use the prices defined in the
-Beancount file, so these should defined manually or by some plugin (using
+In most reports in rustfava, a conversion can be selected with the select
+dropdown at the top of the chart. These conversions will use the prices defined
+in the Beancount file, so these should defined manually or by some plugin (using
 `beancount.plugins.implicit_prices` is recommend to get prices for all costs in
 the Beancount file).
 

--- a/src/rustfava/help/extensions.md
+++ b/src/rustfava/help/extensions.md
@@ -1,15 +1,15 @@
 # Extensions
 
-Rustfava supports extensions. Extensions allow you to register hooks and generate
-your own report pages.
+Rustfava supports extensions. Extensions allow you to register hooks and
+generate your own report pages.
 
 If you use this extension system and need it to do more or need other hooks,
 please open an issue on [GitHub](https://github.com/rustledger/rustfava/issues).
 
-A rustfava extension is simply a Python module which contains a class that inherits
-from `RustfavaExtensionBase` from `rustfava.ext`. Invoking an extension is done via the
-`fava-extension` option in the beancount file. Check out `rustfava.ext.auto_commit`
-for an example.
+A rustfava extension is simply a Python module which contains a class that
+inherits from `RustfavaExtensionBase` from `rustfava.ext`. Invoking an extension
+is done via the `fava-extension` option in the beancount file. Check out
+`rustfava.ext.auto_commit` for an example.
 
 Extensions may also contain a report - this is detected when the extension's
 class has a `report_title` attribute. The template for the report should be in a
@@ -21,12 +21,12 @@ Finally, extensions may contain a Javascript module to be loaded in the
 frontend. The module should be in a Javascript file matching the class's name
 and the extension should have its `has_js_module` attribute set to `True`. The
 module can define functions to be called when different events happen. Take a
-look at `rustfava/ext/portfolio_list/PortfolioList.js` for an example. Currently,
-the following events/functions can be specified:
+look at `rustfava/ext/portfolio_list/PortfolioList.js` for an example.
+Currently, the following events/functions can be specified:
 
 - `init`: is called when a rustfava report is first opened
-- `onPageLoad`: Is called when any page in rustfava is loaded (so on first open and
-  on any further navigation).
+- `onPageLoad`: Is called when any page in rustfava is loaded (so on first open
+  and on any further navigation).
 - `onExtensionPageLoad`: Is called when the extension report is loaded.
 
 The type signature of the extension module is defined in
@@ -47,8 +47,8 @@ in addition to anything on the Python path. Single python files will also be
 searched - so for example a `my_extension.py` could be used by giving
 `my_extension`. Note that Python has a global namespace for currently loaded
 modules, so try avoiding simple names that might coincide with some Python
-library (as well as running rustfava on two files that have different extensions of
-the same name).
+library (as well as running rustfava on two files that have different extensions
+of the same name).
 
 Extensions allow for an optional configuration options string, whose structure
 is specified by the individual extension.

--- a/src/rustfava/help/features.md
+++ b/src/rustfava/help/features.md
@@ -23,8 +23,8 @@ Query Language (BQL). Rustfava uses rustledger's built-in query engine. For an
 explanation of how BQL queries work, see the
 [Beancount Query Language Reference](http://furius.ca/beancount/doc/query).
 
-Rustfava displays charts for BQL queries - if they have exactly two columns like the
-following example with the first being a date or string and the second an
+Rustfava displays charts for BQL queries - if they have exactly two columns like
+the following example with the first being a date or string and the second an
 inventory, then a line chart or treemap chart is shown on the query page.
 
 ```
@@ -46,9 +46,9 @@ work with cost basis or market value instead, wrap the position in the
 SELECT account, COST(SUM(position)), VALUE(SUM(position)) GROUP BY account
 ```
 
-Rustfava supports downloading the result of these queries in various file formats.
-By default, only exporting to `csv` is supported. For support of `xlsx` and
-`ods`, install rustfava with the `excel` feature:
+Rustfava supports downloading the result of these queries in various file
+formats. By default, only exporting to `csv` is supported. For support of `xlsx`
+and `ods`, install rustfava with the `excel` feature:
 
 ```
 uv pip install rustfava[excel]
@@ -60,14 +60,14 @@ By clicking the `+` button or using the `n` keyboard shortcut you can open a
 form to insert a transaction to your Beancount file. The position that
 transactions are inserted at can be specified in a flexible way using the
 [`insert-entry`](./options#insert-entry) option. If you want to set a bookmark
-to this form, adding `#add-transaction` to any URL in rustfava will open it on load.
-Tags and links can be added in the form by adding them (separated by spaces) to
-the narration field, e.g., `narration #tag ^somelink`.
+to this form, adding `#add-transaction` to any URL in rustfava will open it on
+load. Tags and links can be added in the form by adding them (separated by
+spaces) to the narration field, e.g., `narration #tag ^somelink`.
 
 ## Up-to-date indicators
 
-Rustfava offers colored indicators that can help you keep your accounts up-to-date.
-They are shown next to accounts that have the metadata
+Rustfava offers colored indicators that can help you keep your accounts
+up-to-date. They are shown next to accounts that have the metadata
 `fava-uptodate-indication: TRUE` set on their Open directive. The colors have
 the following meaning:
 
@@ -90,8 +90,8 @@ number or a deep hierarchy of accounts, Rustfava offers the following options:
 
 ## Opening an external editor
 
-Rustfava can open up your source file in your favorite editor directly from the web
-interface using the `use-external-editor` configuration variable through the
+Rustfava can open up your source file in your favorite editor directly from the
+web interface using the `use-external-editor` configuration variable through the
 `beancount://` URL handler. See the
 [Beancount urlscheme](https://github.com/aumayr/beancount_urlscheme) project for
 pre-configured URL handlers for macOS and Cygwin.
@@ -103,8 +103,8 @@ Beancount file name on the top left to switch between the files.
 
 ## Custom links in the sidebar
 
-If you regularly use certain views in rustfava with different filters, you can put
-links to them in the sidebar. Custom links can be put in the Beancount file,
+If you regularly use certain views in rustfava with different filters, you can
+put links to them in the sidebar. Custom links can be put in the Beancount file,
 utilizing the `custom` directive:
 
 ```
@@ -129,8 +129,8 @@ current page but change the time filter to the current month.
 ## Language
 
 You can change the language of the interface by specifying the
-[`language`](./options#language) option. If no option is specified, rustfava tries
-to guess the language from your browser settings.
+[`language`](./options#language) option. If no option is specified, rustfava
+tries to guess the language from your browser settings.
 
 ## Documents upload
 

--- a/src/rustfava/help/filters.md
+++ b/src/rustfava/help/filters.md
@@ -1,8 +1,8 @@
 # Filters
 
 With the text inputs at the top right of the page, you can filter the entries
-that are displayed in rustfava's reports. If you use multiple filters, the entries
-matching all of them will be selected.
+that are displayed in rustfava's reports. If you use multiple filters, the
+entries matching all of them will be selected.
 
 ## Time
 
@@ -22,8 +22,8 @@ the 10th of this month, whereas `month-10` would be 10 months ago.
 
 ### Summarisation of previous balances and conversions
 
-When setting a time filter, rustfava does not just filter to the transactions in the
-interval but also summarises transactions in the following ways (using
+When setting a time filter, rustfava does not just filter to the transactions in
+the interval but also summarises transactions in the following ways (using
 Beancount's "clamp" summarisation):
 
 - All balances for the Income and Expenses accounts previous to the filtered
@@ -74,8 +74,8 @@ This final filter allows you to filter entries by various attributes.
 - Filter by any entry attribute, such as payee `payee:"restaurant"` or narration
   `narration:'Dinner with Joe'`. The argument is a regular expression which
   needs to be quoted (with `'` or `"`) if it contains spaces or special
-  characters. If the argument is not a valid regular expression, rustfava will look
-  for an exact match instead.
+  characters. If the argument is not a valid regular expression, rustfava will
+  look for an exact match instead.
 - Search in payee and narration if no specific entry attribute is given, e.g.
   `"Cash withdrawal"`. For Note directives, the comment will be searched.
 - Filter for entries having certain metadata values: `document:"\.pdf$"`. Note

--- a/src/rustfava/help/import.md
+++ b/src/rustfava/help/import.md
@@ -1,7 +1,8 @@
 # Import
 
-Rustfava can use Beancount's import system to semi-automatically import entries into
-your ledger. See [Importing External Data in Beancount](http://furius.ca/beancount/doc/ingest)
+Rustfava can use Beancount's import system to semi-automatically import entries
+into your ledger. See
+[Importing External Data in Beancount](http://furius.ca/beancount/doc/ingest)
 for more information on how to write importers.
 
 **Note**: Import functionality requires the beancount compatibility package.
@@ -12,8 +13,8 @@ variable `HOOKS` with a list of hooks to apply to the list of
 `(filename: str, entries: list[Directive])` tuples. If you want to use
 beangulp-style hooks that take lists of
 `(filename: str, entries: list[Directive], account: str, importer: Importer)`-tuples,
-you can annotate them with the appropriate Python types which rustfava will detect
-and call with these 4-tuples.
+you can annotate them with the appropriate Python types which rustfava will
+detect and call with these 4-tuples.
 
 Set the `import-config` option to point to your import config and set
 `import-dirs` to the directories that contain the files that you want to import.

--- a/src/rustfava/help/options.md
+++ b/src/rustfava/help/options.md
@@ -16,8 +16,8 @@ ______________________________________________________________________
 
 Default: Not set
 
-If this setting is not specified, rustfava will try to guess the language from your
-browser settings. Rustfava currently ships translations into the following
+If this setting is not specified, rustfava will try to guess the language from
+your browser settings. Rustfava currently ships translations into the following
 languages:
 
 - Bulgarian (`bg`)
@@ -60,8 +60,8 @@ ______________________________________________________________________
 
 Default: `income_statement/`
 
-Use this option to specify the page to be redirected to when visiting rustfava. If
-this option is not specified, you are taken to the income statement. You may
+Use this option to specify the page to be redirected to when visiting rustfava.
+If this option is not specified, you are taken to the income statement. You may
 also use this option to set filters. For example, a `default-page` of
 `balance_sheet/?time=year-2+-+year` would result in you being redirected to a
 balance sheet reporting the current year and the two previous years.
@@ -123,11 +123,11 @@ ______________________________________________________________________
 
 Default: `false`
 
-Set this to `true` to make rustfava automatically reload the page whenever a file
-changes is detected. By default only a notification is shown which you can click
-to reload the page. If the file change is due to user interaction, e.g.,
-uploading a document or adding a transaction, rustfava will always reload the page
-automatically.
+Set this to `true` to make rustfava automatically reload the page whenever a
+file changes is detected. By default only a notification is shown which you can
+click to reload the page. If the file change is due to user interaction, e.g.,
+uploading a document or adding a transaction, rustfava will always reload the
+page automatically.
 
 ______________________________________________________________________
 
@@ -145,9 +145,9 @@ ______________________________________________________________________
 Default: `61`
 
 This option can be used to configure how posting lines are aligned when saved to
-file or when using 'Align Amounts' in the editor. rustfava tries to align so that
-the currencies all occur in the given column. Also, rustfava will show a vertical
-line before this column in the editor.
+file or when using 'Align Amounts' in the editor. rustfava tries to align so
+that the currencies all occur in the given column. Also, rustfava will show a
+vertical line before this column in the editor.
 
 ______________________________________________________________________
 
@@ -252,9 +252,9 @@ ______________________________________________________________________
 
 Default: `false`
 
-By default, rustfava uses green for unrealized gains (positive values) and red for
-unrealized losses (negative values) in the Balance Sheet and Trial Balance when
-displaying at market value.
+By default, rustfava uses green for unrealized gains (positive values) and red
+for unrealized losses (negative values) in the Balance Sheet and Trial Balance
+when displaying at market value.
 
 Set this to `true` to invert the color scheme, using red for gains and green for
 losses. This is useful for users from regions where the opposite convention is
@@ -271,9 +271,10 @@ In Beancount the Income, Liabilities and Equity accounts tend to have a negative
 balance (see
 [Types of Accounts](https://beancount.github.io/docs/the_double_entry_counting_method.html#types-of-accounts)).
 
-This rustfava option flips the sign of these three accounts in the income statement
-and the balance sheet. This way, the net profit chart will show positive numbers
-if the income is greater than the expenses for a given timespan.
+This rustfava option flips the sign of these three accounts in the income
+statement and the balance sheet. This way, the net profit chart will show
+positive numbers if the income is greater than the expenses for a given
+timespan.
 
 Note: To keep consistency with the internal accounting of beancount, the journal
 and the individual account pages are not affected by this configuration option.


### PR DESCRIPTION
The `mdformat` hook only runs on files a push actually touches, so this debt surfaced one file at a time — always while someone was trying to do something else. #298 and #240 both had to reach for `--no-verify`. This clears all 18 remaining files so the hook stops being a tripwire.

Purely presentational: prose rewrapped to 80 columns, table separators padded, ordered lists normalized to lazy `1.` numbering (renders identically), `---` thematic breaks rewritten as `___`.

## The nine help pages got extra scrutiny

These render in the app, so I didn't want to bulk-apply and hope:

- **Every `<pre>` and `<textarea>` block is byte-identical** before and after — verified by extracting and comparing them programmatically, not by eye. Those are the whitespace-significant regions, and there are 34 across the help pages.
- **The help pages are Jinja-rendered.** `application.py` passes the rendered markdown through `render_template_string(html, rustfava_version=...)`, so `{{ rustfava_version }}` in `_index.md` is a live substitution, not literal text. Placeholder counts match before and after in every file, and the one placeholder is unchanged.
- **Prose changes are soft line breaks only**, which CommonMark collapses to spaces — including the lines that wrap `<kbd>` and link spans.

## Content preservation

Checked across all 18 by diffing token streams before and after. The only differences are ordered-list markers (`2.` → `1.`) and table pipes from separator padding. **No prose word changed.**

## Verification

- `671 passed, 1 skipped`
- `mdformat --all-files` now **Passes** — idempotent repo-wide
- This branch was pushed **without `--no-verify`**, which is the point: the pre-push hook ran and passed on its own

Worth noting the other half of that tripwire is already gone — #240 fixed `update-flake-sources.yml` for prettier, so pre-push is now clean for both hooks.