### PR TITLE
fix(desktop): ad-hoc sign the macOS bundle

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -44,7 +44,8 @@
       }
     },
     "macOS": {
-      "minimumSystemVersion": "10.15"
+      "minimumSystemVersion": "10.15",
+      "signingIdentity": "-"
     },
     "windows": {
       "webviewInstallMode": {


### PR DESCRIPTION
Addresses the launch failure in #272 — the aarch64 build reports *"rustfava is damaged and can't be opened"*.

That wording is Gatekeeper's and it's misleading: the bundle isn't corrupt, it's **unsigned**. On Apple Silicon this is fatal rather than advisory — arm64 macOS requires every executable to carry at least an ad-hoc signature, so an unsigned arm64 app cannot launch from a downloaded `.dmg` at all.

Nothing in the release path signed it. Grepping `.github/workflows/`, `desktop/src-tauri/tauri.conf.json` and `desktop/` for `notariz`, `codesign`, `APPLE_ID`, `signingIdentity`, `hardenedRuntime`, `entitlements` returned **no matches anywhere**.

## The change

```json
"macOS": {
  "minimumSystemVersion": "10.15",
  "signingIdentity": "-"
}
```

`"-"` is passed straight through to `codesign --force -s -` — tauri-macos-sign's `keychain.rs` builds `vec!["--force", "-s", &identity]` — which is the ad-hoc invocation. No certificate, no Apple account, no secrets.

## Checked before choosing this over a CI env var

- **A future real identity overrides it cleanly.** `APPLE_SIGNING_IDENTITY` *overwrites* `bundle > macOS > signingIdentity` per tauri-cli's `ENVIRONMENT_VARIABLES.md`, so adding a Developer ID later needs no change here.
- **It does not trigger a notarization attempt.** `tauri-bundler` only notarizes when `notarize_auth()` finds credentials; with none set it logs `skipping app notarization` and continues. The one hard-fail case is a missing team ID *alongside* an Apple ID, which doesn't apply.
- **The config still validates** against `schema.tauri.app/config/2` — checked against the fetched schema, and I confirmed `signingIdentity` is declared on `MacConfig` rather than assuming it.

## What this does and doesn't do

It does **not** make the app notarized. First launch still shows the unidentified-developer prompt. Proper notarization needs a Developer ID certificate plus `notarytool` — a paid Apple account and four secrets, so a maintainer decision rather than something to land unilaterally.

What it changes is the failure mode: from **"damaged, cannot open"** (no way through without `xattr`) to **"unidentified developer, open anyway"** (right-click → Open). That's the difference between unusable and usable.

I can't build or verify a macOS bundle from here, so the real proof is the next desktop release artifact launching on Apple Silicon.