### PR TITLE
feat: bind session.returns, and fix result<> marshalling it exposed

### DIFF
--- a/src/rustfava/rustledger/component_engine.py
+++ b/src/rustfava/rustledger/component_engine.py
@@ -416,6 +416,26 @@ def _unwrap_meta_value(value: Any) -> Any:
     return value
 
 
+def _payload_matches(value: Any, ok_type: Any) -> bool:
+    """Whether an untagged `result` payload is the ``ok`` arm, not the error.
+
+    wasmtime-py drops the tag (see :func:`_marshal`), so the declared ``ok``
+    type is the only discriminator available. This is decisive whenever ``ok``
+    is not a bare string — a `returns-result` Record cannot be confused with an
+    error message. It is genuinely undecidable for `result<string, string>`,
+    where both arms lift to `str`; those are treated as success, because the
+    component signals its failures for such functions by trapping rather than
+    returning, and mis-reading a real string as an error would be worse.
+    """
+    if isinstance(ok_type, RecordType):
+        return isinstance(value, Record)
+    if isinstance(ok_type, VariantType):
+        return isinstance(value, Variant)
+    # Every other `ok` in rustledger's WIT is a primitive, where the arms are
+    # indistinguishable; treat those as success (see the docstring).
+    return True
+
+
 def _marshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911, PLR0912
     """Convert a component value into plain Python, driven by its WIT type.
 
@@ -481,13 +501,22 @@ def _marshal(value: Any, vtype: Any) -> Any:  # noqa: PLR0911, PLR0912
             _marshal(v, t) for v, t in zip(value, vtype.elements, strict=False)
         ]
     if isinstance(vtype, ResultType):
-        # `result<ok, err>` lifts to a Variant(tag="ok"|"err"); wasmtime-py
-        # does NOT raise. Surface `err` as an exception, unwrap `ok`.
-        if value.tag == "err":
-            err = _marshal(value.payload, vtype.err) if vtype.err else None
-            msg = str(err) if err is not None else "component error"
-            raise RustledgerError(msg)
-        return _marshal(value.payload, vtype.ok) if vtype.ok else None
+        # `result<ok, err>` does NOT raise, and wasmtime-py hands back the
+        # PAYLOAD ALONE — no tag. `session.returns` returns the bare
+        # `returns-result` Record on success and a bare `str` on failure, so
+        # the two are told apart by type against the declared `ok`.
+        #
+        # A tagged Variant is still accepted first, so this keeps working if a
+        # wasmtime-py version lifts the tag.
+        if isinstance(value, Variant) and value.tag in {"ok", "err"}:
+            if value.tag == "err":
+                err = _marshal(value.payload, vtype.err) if vtype.err else None
+                msg = str(err) if err is not None else "component error"
+                raise RustledgerError(msg)
+            return _marshal(value.payload, vtype.ok) if vtype.ok else None
+        if _payload_matches(value, vtype.ok):
+            return _marshal(value, vtype.ok)
+        raise RustledgerError(str(value))
     # Fallback: an un-typed Record/Variant, an enum (lifts to str), or a
     # primitive.
     if isinstance(value, Record):
@@ -1072,6 +1101,40 @@ class ComponentSession:
         """Run a BQL query against the held ledger."""
         return _finalize_query_result(
             self._method("[method]session.query", query_string)
+        )
+
+    def returns(
+        self,
+        investments: list[str],
+        income: list[str],
+        currency: str,
+        end_date: str,
+    ) -> dict[str, Any]:
+        """Money-weighted (XIRR) and time-weighted returns over the ledger.
+
+        ``investments`` / ``income`` are account-name *prefixes* defining the
+        scope, mirroring ``rledger report returns --investments/--income``.
+        ``currency`` may be ``""`` to fall back to the ledger's first
+        ``operating_currency``. ``end_date`` (``YYYY-MM-DD``) is required — a
+        component has no clock — and is both the horizon and the terminal
+        valuation date.
+
+        The returned ``invested`` / ``distributions`` / ``current_value`` are
+        raw full-precision decimal strings, deliberately unformatted, so the
+        caller formats them for its locale. ``money_weighted`` /
+        ``time_weighted`` are annualized fractions (``0.1`` is 10%) and are
+        ``None`` where undefined.
+
+        The engine is strict about this: an unpriceable flow, an unresolvable
+        reporting currency, or a booking error raises rather than returning a
+        number that cannot be trusted.
+        """
+        return self._method(
+            "[method]session.returns",
+            investments,
+            income,
+            currency,
+            end_date,
         )
 
     def filter(self, begin_date: str, end_date: str) -> list[dict[str, Any]]:

--- a/tests/test_rustledger_component_engine.py
+++ b/tests/test_rustledger_component_engine.py
@@ -10,6 +10,7 @@ Build the component with::
 from __future__ import annotations
 
 import tempfile
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -446,3 +447,56 @@ def test_open_session_entries_holds_and_queries(
     assert sorted(map(str, held["rows"])) == sorted(map(str, shipped["rows"]))
     # The session holds ALL the entries it was given.
     assert len(session.info()["entries"]) == len(entries)
+
+
+SRC_RETURNS = (
+    "2024-01-01 open Assets:Cash USD\n"
+    "2024-01-01 open Assets:Invest:Fund FUND\n"
+    "2024-01-01 open Income:Invest:Dividend USD\n"
+    '2024-01-02 * "buy"\n'
+    "  Assets:Invest:Fund  10 FUND {10 USD}\n"
+    "  Assets:Cash\n"
+    '2024-06-01 * "dividend"\n'
+    "  Assets:Cash  5 USD\n"
+    "  Income:Invest:Dividend\n"
+    "2024-12-31 price FUND  12 USD\n"
+)
+
+
+def test_session_returns_computes_money_and_time_weighted(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """`session.returns` reports the scope's flows and both return metrics.
+
+    The decimal fields come back as raw full-precision strings by design —
+    the host formats them — so they are asserted as strings, not floats.
+    """
+    session = engine.open_session(SRC_RETURNS)
+    result = session.returns(
+        ["Assets:Invest"], ["Income:Invest"], "USD", "2024-12-31"
+    )
+
+    assert result["cash_flows"] > 0
+    assert isinstance(result["invested"], str)
+    assert isinstance(result["distributions"], str)
+    assert isinstance(result["current_value"], str)
+    # 10 FUND bought at 10 USD, valued at 12 USD on the end date.
+    assert Decimal(result["current_value"]) == Decimal(120)
+    assert Decimal(result["invested"]) == Decimal(100)
+    # Annualized fractions, or None where undefined.
+    for key in ("money_weighted", "time_weighted"):
+        assert result[key] is None or isinstance(result[key], float)
+
+
+def test_session_returns_surfaces_engine_errors(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """An `err(message)` arm becomes a RustledgerError, not a bogus number.
+
+    wasmtime-py drops the `result` tag and hands back the payload alone, so
+    success and failure are told apart by type: a `returns-result` Record
+    versus a bare `str`. This is the first binding to exercise that path.
+    """
+    session = engine.open_session(SRC_RETURNS)
+    with pytest.raises(RustledgerError, match="end-date"):
+        session.returns(["Assets:Invest"], ["Income:Invest"], "USD", "nope")

--- a/tests/test_rustledger_component_marshal.py
+++ b/tests/test_rustledger_component_marshal.py
@@ -138,6 +138,17 @@ def _builder_func_type(engine: RustledgerComponentEngine, name: str) -> Any:
     return func.type(engine._store)
 
 
+def _session_func_type(engine: RustledgerComponentEngine, name: str) -> Any:
+    """The wasmtime func type of a `session` method, for its declared types."""
+    session = engine.open_session("2024-01-01 open Assets:Cash USD\n")
+    idx = engine._component.get_export_index(
+        f"[method]session.{name}",
+        engine._iface(ce._LEDGER),
+    )
+    func = session._inst.get_func(session._store, idx)
+    return func.type(session._store)
+
+
 def test_marshal_result_err_raises(engine: RustledgerComponentEngine) -> None:
     """result<ok, err> lifting: err surfaces as RustledgerError, ok unwraps.
 
@@ -532,3 +543,53 @@ def test_prune_superseded_components_tolerates_unremovable(
     _prune_superseded_components(current)  # must not raise
 
     assert older.exists()
+
+
+def test_payload_matches_discriminates_by_declared_ok_type(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """Untagged `result` payloads are classified against the declared `ok`.
+
+    wasmtime-py drops the tag, so this is the only discriminator available.
+    It is decisive whenever `ok` is not a bare string: a Record cannot be
+    mistaken for an error message.
+    """
+    returns_type = _session_func_type(engine, "returns").result
+    ok_record_type = returns_type.ok
+    assert isinstance(ok_record_type, RecordType)
+
+    # A Record is the ok arm; a bare string is the error arm. The Record is a
+    # real one from the component rather than a fabricated stand-in — the
+    # previous `result` test passed only because it hand-built a tagged
+    # Variant the runtime never actually produces.
+    session = engine.open_session(SRC_RETURNS_MARSHAL)
+    real_record = session.returns(["Assets:Invest"], [], "USD", "2024-12-31")
+    assert isinstance(real_record, dict)  # marshalled ok arm
+    assert not ce._payload_matches("no price for FOO", ok_record_type)
+
+    # Variant and list ok-types classify on their own shapes.
+    create_ok = _builder_func_type(engine, "create").result.ok
+    assert ce._payload_matches(Variant("transaction", None), create_ok)
+    assert not ce._payload_matches("boom", create_ok)
+
+    # A primitive ok-type is undecidable, so anything is treated as success.
+    assert ce._payload_matches("anything", String())
+
+
+def test_marshal_untagged_result_raises_on_error_payload(
+    engine: RustledgerComponentEngine,
+) -> None:
+    """The error arm of an untagged `result` becomes a RustledgerError."""
+    returns_type = _session_func_type(engine, "returns").result
+    with pytest.raises(RustledgerError, match="no price"):
+        ce._marshal("no price for FOO", returns_type)
+
+
+SRC_RETURNS_MARSHAL = (
+    "2024-01-01 open Assets:Cash USD\n"
+    "2024-01-01 open Assets:Invest:Fund FUND\n"
+    '2024-01-02 * "buy"\n'
+    "  Assets:Invest:Fund  10 FUND {10 USD}\n"
+    "  Assets:Cash\n"
+    "2024-12-31 price FUND  12 USD\n"
+)


### PR DESCRIPTION
Second checklist item of #263. The first is already satisfied — `main` pins rustledger v0.22.0, whose WIT declares `rustledger:ledger@3.11.0` and exports `session.returns`.

Binding it turned out to require fixing `_marshal`, because **this is the first caller to reach a `result<ok, err>` return with a real component value.**

## The marshalling bug

`_marshal` assumed `result` lifts to a `Variant(tag="ok"|"err")` and read `value.tag`. wasmtime-py doesn't do that — it hands back the **payload alone, with no tag**. `session.returns` returns a bare `returns-result` Record on success and a bare `str` on failure, so the error path raised:

```
AttributeError: 'str' object has no attribute 'tag'
```

The branch was nonetheless at **100% coverage**, because its test builds `Variant("err", "boom")` by hand — a shape the runtime never produces. Same trap as a sweep that only ever reports clean: the test couldn't fail, because its input couldn't occur. The new tests use a real Record from an actual call.

Nothing regressed, because nothing previously reached it: `session.format` and `session.returns` are the only `result`-returning methods in the WIT, and neither was bound.

## The fix

The tagged shape is still accepted first, so a future wasmtime-py that lifts the tag keeps working. Otherwise the untagged payload is classified against the declared `ok` type — decisive whenever `ok` is a record or variant. It's genuinely undecidable for `result<string, string>`, where both arms lift to `str`; those are treated as success, and the docstring says so rather than pretending otherwise.

I dropped two unreachable arms instead of fabricating coverage: rustledger's WIT has no `result<list<…>, …>`, and its only bare `result<_, …>` are WASI stream imports that never pass through here.

## Verified against the real component

```
returns(["Assets:Invest"], ["Income:Invest"], "USD", "2024-12-31")
  -> cash_flows 13, invested "8500", current_value "8341.47",
     money_weighted -0.0334…, time_weighted -0.0500…

returns(..., end_date="not-a-date")
  -> RustledgerError: invalid end-date "not-a-date" (expected YYYY-MM-DD)

returns(scope spanning an unpriced currency)
  -> RustledgerError: no price to convert IRAUSD to the reporting currency
```

The decimal fields stay raw full-precision strings by design — the host formats them — so the tests assert on strings and `Decimal`, not floats.

**675 passed, coverage gate 100%, mypy clean.**

## Still open on #263

The view itself: scope/currency/as-of pickers, locale formatting of the raw decimals, and rendering an `err` as "cannot compute returns" rather than a blank chart. This PR is the plumbing that unblocks it.