### PR TITLE
fix(release): stop RUSTFAVA_VERSION breaking the sidecar smoke test

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -151,12 +151,22 @@ jobs:
               print(f'Compiled {po} -> {mo}')
           "
 
-      - name: Set RUSTFAVA_VERSION from tag
+      - name: Set FROZEN_APP_VERSION from tag
         # The spec bakes this into rustfava/_version.py so the frozen binary
         # reports the real version without dist-info metadata (issue #191).
+        #
+        # Deliberately NOT named RUSTFAVA_VERSION. The CLI is declared with
+        # `auto_envvar_prefix: "RUSTFAVA"` (cli.py), so click maps
+        # RUSTFAVA_VERSION onto `--version` — a boolean flag. Writing it to
+        # $GITHUB_ENV leaks it into every later step in the job, including the
+        # smoke test that actually runs the frozen binary, which then died with
+        # `Invalid value for '--version': '1.32.0' is not a valid boolean`
+        # before serving anything. Only tag builds set it, so the collision
+        # first appeared on v1.32.0 — the first tagged release after the smoke
+        # test was added in #239.
         if: startsWith(github.ref, 'refs/tags/')
         shell: bash
-        run: echo "RUSTFAVA_VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"
+        run: echo "FROZEN_APP_VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"
 
       - name: Build sidecar with PyInstaller
         shell: bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,8 +35,20 @@ Monitor at: https://github.com/rustledger/rustfava/actions
 
 ### 3. PyPI deployment
 
-Publishes automatically when the `build-publish.yml` workflow reaches the `pypi`
-job — no manual approval is configured (verified during v1.31.0).
+The workflow is `publish.yml` (this document previously called it
+`build-publish.yml`, which does not exist).
+
+Its `publish` job targets the **`pypi` environment, which has protection rules**
+— the run sits in `waiting` until a deployment reviewer approves it. Approve at
+the run's page, or:
+
+```bash
+gh api repos/rustledger/rustfava/actions/runs/<run-id>/pending_deployments \
+  -f state=approved -f "environment_ids[]=<id>" -f comment=""
+```
+
+Everything before it (`build`, `docker`, `smoke-wheel`) runs unattended, so the
+Docker image publishes without approval — only PyPI waits.
 
 ### 4. Publish the GitHub release
 

--- a/contrib/pyinstaller_spec.spec
+++ b/contrib/pyinstaller_spec.spec
@@ -89,11 +89,13 @@ except Exception:
 # Ensure rustfava can report its version from the frozen binary. The bundle
 # ships no dist-info metadata, so importlib.metadata.version() fails and
 # rustfava falls back to rustfava._version (see issue #191). Generate that
-# module here from RUSTFAVA_VERSION (set from the git tag on release builds)
+# module here from FROZEN_APP_VERSION (set from the git tag on release builds;
+# named outside the RUSTFAVA_ prefix because click's auto_envvar_prefix would
+# otherwise read it as the `--version` flag when the frozen binary runs)
 # or setuptools_scm when building from a full source checkout.
 version_file = rustfava_dir / "_version.py"
 if not version_file.exists():
-    version = os.environ.get("RUSTFAVA_VERSION")
+    version = os.environ.get("FROZEN_APP_VERSION")
     if not version:
         try:
             from setuptools_scm import get_version


### PR DESCRIPTION
The v1.32.0 desktop release failed on **every platform**:

```
Error: Invalid value for '--version': '1.32.0' is not a valid boolean.
##[error]frozen sidecar failed to start or serve (the #233 failure class)
```

## Not a packaging problem

`desktop-release.yml` writes `RUSTFAVA_VERSION=<tag>` into `$GITHUB_ENV` so the PyInstaller spec can bake the version into `rustfava/_version.py` (#191). `$GITHUB_ENV` leaks into **every later step of the job** — including the one that actually runs the frozen binary.

The CLI is declared `@click.command(context_settings={"auto_envvar_prefix": "RUSTFAVA"})` (`cli.py:51`), so click reads `RUSTFAVA_VERSION` as `--version`, which is a **boolean flag**. The sidecar exited on a usage error before serving anything, and the smoke test correctly reported it dead.

Only tag builds set the variable, so this could not appear on a PR or on `main`. **v1.32.0 is the first tagged release since the smoke test was added in #239** — a check that only runs in the one situation nobody could test.

## Fix

Renamed to `FROZEN_APP_VERSION` at both sites, deliberately outside the `RUSTFAVA_` prefix so no future internal variable can be re-read as a CLI option.

Verified both directions locally:

```
RUSTFAVA_VERSION=1.32.0   rustfava --port … ledger  -> usage error, exit 120
FROZEN_APP_VERSION=1.32.0 rustfava --port … ledger  -> serves normally
```

## Also: RELEASING.md was wrong twice

Found while working the release:

- It names `build-publish.yml`, which doesn't exist — the workflow is `publish.yml`.
- It states PyPI *"publishes automatically … no manual approval is configured"*. The `pypi` environment has **2 protection rules**, so the `publish` job sits in `waiting` until a reviewer approves. Observed on this release: `build`, `docker` and `smoke-wheel` all completed unattended and only PyPI stopped.